### PR TITLE
Add progress indicator on dock icon

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		CAFE4AB425B7D3AF0064FE51 /* AdvancedPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4AB325B7D3AF0064FE51 /* AdvancedPreferencePane.swift */; };
 		CAFE4ABC25B7D54B0064FE51 /* UpdatesPreferencePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFE4ABB25B7D54B0064FE51 /* UpdatesPreferencePane.swift */; };
 		CAFFFED8259CDA5000903F81 /* XcodeListViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFFFED7259CDA5000903F81 /* XcodeListViewRow.swift */; };
+		E689540325BE8C64000EBCEA /* DockProgress in Frameworks */ = {isa = PBXBuildFile; productRef = E689540225BE8C64000EBCEA /* DockProgress */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -276,6 +277,7 @@
 				CAFE4AA325B7CF960064FE51 /* Preferences in Frameworks */,
 				CABFA9E42592F08E00380FEE /* Version in Frameworks */,
 				CABFA9FD2592F13300380FEE /* LegibleError in Frameworks */,
+				E689540325BE8C64000EBCEA /* DockProgress in Frameworks */,
 				CA9FF86D25951C6E00E47BAF /* XCModel in Frameworks */,
 				CABFA9F82592F0F900380FEE /* KeychainAccess in Frameworks */,
 				CAA858CD25A3D8BC00ACF8C0 /* ErrorHandling in Frameworks */,
@@ -591,6 +593,7 @@
 				CAA858CC25A3D8BC00ACF8C0 /* ErrorHandling */,
 				CAFE4A9925B7C7A30064FE51 /* Sparkle */,
 				CAFE4AA225B7CF960064FE51 /* Preferences */,
+				E689540225BE8C64000EBCEA /* DockProgress */,
 			);
 			productName = XcodesMac;
 			productReference = CAD2E79E2449574E00113D76 /* Xcodes.app */;
@@ -659,6 +662,7 @@
 				CAC28186259EE27200B8AB0B /* XCRemoteSwiftPackageReference "CombineExpectations" */,
 				CAFE4A9825B7C7A30064FE51 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				CAFE4AA125B7CF960064FE51 /* XCRemoteSwiftPackageReference "Preferences" */,
+				E689540125BE8C64000EBCEA /* XCRemoteSwiftPackageReference "DockProgress" */,
 			);
 			productRefGroup = CAD2E79F2449574E00113D76 /* Products */;
 			projectDirPath = "";
@@ -1341,6 +1345,14 @@
 				minimumVersion = 2.2.0;
 			};
 		};
+		E689540125BE8C64000EBCEA /* XCRemoteSwiftPackageReference "DockProgress" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/DockProgress";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1397,6 +1409,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CAFE4AA125B7CF960064FE51 /* XCRemoteSwiftPackageReference "Preferences" */;
 			productName = Preferences;
+		};
+		E689540225BE8C64000EBCEA /* DockProgress */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E689540125BE8C64000EBCEA /* XCRemoteSwiftPackageReference "DockProgress" */;
+			productName = DockProgress;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "DockProgress",
+        "repositoryURL": "https://github.com/sindresorhus/DockProgress",
+        "state": {
+          "branch": null,
+          "revision": "7100b68571e2dafe3a06ad5905b80fc3b0107b4b",
+          "version": "3.2.0"
+        }
+      },
+      {
         "package": "ErrorHandling",
         "repositoryURL": "https://github.com/RobotsAndPencils/ErrorHandling",
         "state": {

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -6,6 +6,7 @@ import LegibleError
 import KeychainAccess
 import Path
 import Version
+import DockProgress
 
 class AppState: ObservableObject {
     private let client = AppleAPI.Client()
@@ -298,6 +299,9 @@ class AppState: ObservableObject {
 
         // Cancel the publisher
         installationPublishers[id] = nil
+        
+        // Remove dock icon progress indicator
+        DockProgress.progress = 1 // Only way to completely remove overlay with DockProgress is setting progress to complete
                 
         // If the download is cancelled by the user, clean up the download files that aria2 creates.
         // This isn't done as part of the publisher with handleEvents(receiveCancel:) because it shouldn't happen when e.g. the app quits.

--- a/Xcodes/Frontend/XcodeList/InstallationStepView.swift
+++ b/Xcodes/Frontend/XcodeList/InstallationStepView.swift
@@ -17,7 +17,7 @@ struct InstallationStepView: View {
                     controlSize: .small,
                     style: .spinning
                 )
-                .help("Dowloading: \(Int((progress.fractionCompleted * 100)))% complete")
+                .help("Downloading: \(Int((progress.fractionCompleted * 100)))% complete")
             case .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
                 ProgressView()
                     .scaleEffect(0.5)

--- a/Xcodes/Resources/Licenses.rtf
+++ b/Xcodes/Resources/Licenses.rtf
@@ -323,6 +323,21 @@ For more information, please refer to &lt;<http://unlicense.org/>&gt;\
     otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.\
 \
 
+\fs34 DockProgress\
+\
+
+\fs26 MIT License\
+\
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\
+\
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
+\
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
+\
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
+\
+\
+
 \fs34 KeychainAccess\
 \
 


### PR DESCRIPTION
Closes #17

Uses suggested [DockProgress](https://github.com/sindresorhus/DockProgress) to display a progress bar overlay on top of the dock icon as an Xcode is downloading.

<img width="794" alt="Screen Shot 2021-01-24 at 10 41 38 PM" src="https://user-images.githubusercontent.com/818102/105667060-e2054180-5e97-11eb-8caf-aa4f6488372e.png">