### PR TITLE
Add support for pasting the entire 2FA code

### DIFF
--- a/Xcodes/Frontend/SignIn/PinCodeTextView.swift
+++ b/Xcodes/Frontend/SignIn/PinCodeTextView.swift
@@ -139,7 +139,15 @@ class PinCodeTextView: NSControl, NSTextFieldDelegate {
         else { return } 
         
         let newFieldText = field.stringValue
-        
+
+        // If we are focused on the first field and pasting a 6-digit string,
+        // treat it as pasting the entire code and focus on the last field
+        if code.isEmpty && newFieldText.count == numberOfDigits {
+            code = Array(newFieldText)
+            window?.makeFirstResponder(characterViews.last)
+            return
+        }
+
         let lastCharacter: Character?
         if newFieldText.isEmpty {
             lastCharacter = nil


### PR DESCRIPTION
### Goals
This PR adds support for pasting the entire 2FA code if the new string equals the length of the expected 2FA code. Currently, when pasting the 2FA code, only the last digit gets pasted.

### Notes
I think it makes sense to have this behavior only if the user didn't enter any digit so that we can avoid any weird edge cases that could override their input, but let me know if you disagree.

### Demo

https://user-images.githubusercontent.com/16192914/168834317-5358b584-261c-4f7f-93f3-0ededd350410.mov
