### PR TITLE
Show alternating row backgrounds on XcodeListView

### DIFF
--- a/Xcodes/Frontend/XcodeList/XcodeListView.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListView.swift
@@ -39,8 +39,16 @@ struct XcodeListView: View {
     }
     
     var body: some View {
-        List(visibleXcodes, selection: $selectedXcodeID) { xcode in
-            XcodeListViewRow(xcode: xcode, selected: selectedXcodeID == xcode.id, appState: appState)
+        // We have this version check to show alternating row backgrounds when available
+        if #available(macOS 12, *) {
+            List(visibleXcodes, selection: $selectedXcodeID) { xcode in
+                XcodeListViewRow(xcode: xcode, selected: selectedXcodeID == xcode.id, appState: appState)
+            }
+            .listStyle(.inset(alternatesRowBackgrounds: true))
+        } else {
+            List(visibleXcodes, selection: $selectedXcodeID) { xcode in
+                XcodeListViewRow(xcode: xcode, selected: selectedXcodeID == xcode.id, appState: appState)
+            }
         }
     }
 }


### PR DESCRIPTION
This improves readability, expecially when doing actions like selecting the install button of a specific version. The view modifier for this requires macOS 12, so macOS 11 will not have alternating row backgrounds.

![Screenshot of the app, now with alternating row backgrounds](https://user-images.githubusercontent.com/44349936/236596662-fcdba783-a354-41fc-b75c-d1fb91c00df7.png)
