### PR TITLE
Sendable Conformance for Process

### DIFF
--- a/Xcodes/Backend/Process.swift
+++ b/Xcodes/Backend/Process.swift
@@ -73,3 +73,7 @@ struct ProcessExecutionError: Error {
     let standardOutput: String
     let standardError: String
 }
+
+extension Process: @unchecked Sendable {
+    
+}


### PR DESCRIPTION
Xcode was warning about "Stored property 'process' of 'Sendable'-conforming struct 'ProcessExecutionError' has non-sendable type 'Process'" The solution has been inspired by [this](https://www.avanderlee.com/swift/sendable-protocol-closures/#:~:text=Stored%20property%20%E2%80%98author%E2%80%99%20of%20%E2%80%98Sendable%E2%80%99%2Dconforming%20struct%20%E2%80%98ArticleSavingError%E2%80%99%20has%20non%2Dsendable%20type%20%E2%80%98NonFinalAuthor) article.
@ unchecked is added since the extension conformance was not in the source code's file(Process class) and Xcode was recommending to add one.