### PR TITLE
Add PinCodeTextField autocomplete support

### DIFF
--- a/Xcodes/Frontend/SignIn/PinCodeTextView.swift
+++ b/Xcodes/Frontend/SignIn/PinCodeTextView.swift
@@ -6,10 +6,12 @@ struct PinCodeTextField: NSViewRepresentable {
 
     @Binding var code: String
     let numberOfDigits: Int
+    let complete: (String) -> Void
 
     func makeNSView(context: Context) -> NSViewType {
         let view = PinCodeTextView(numberOfDigits: numberOfDigits, itemSpacing: 10)
-        view.codeDidChange = { c in code = c  }
+        view.codeDidChange = { c in code = c }
+        view.codeDidComplete = { complete($0) }
         return view
     }
     
@@ -29,8 +31,9 @@ struct PinCodeTextField_Previews: PreviewProvider {
     struct PreviewContainer: View {
         @State private var code = "1234567890"
         var body: some View {
-            PinCodeTextField(code: $code, numberOfDigits: 11)
-                .padding()
+            PinCodeTextField(code: $code, numberOfDigits: 11) {
+                print("Input is complete \($0)")
+            }.padding()
         }
     }
 
@@ -52,10 +55,16 @@ class PinCodeTextView: NSControl, NSTextFieldDelegate {
                 handler(String(code.compactMap { $0 }))
             }
             updateText()
+            
+            if code.compactMap({ $0 }).count == numberOfDigits,
+               let handler = codeDidComplete {
+                handler(String(code.compactMap { $0 }))
+            }
         }
     }
     var codeDidChange: ((String) -> Void)? = nil
-    
+    var codeDidComplete: ((String) -> Void)? = nil
+
     private let numberOfDigits: Int
     private let stackView: NSStackView = .init(frame: .zero)
     private var characterViews: [PinCodeCharacterTextField] = []

--- a/Xcodes/Frontend/SignIn/SignIn2FAView.swift
+++ b/Xcodes/Frontend/SignIn/SignIn2FAView.swift
@@ -15,7 +15,9 @@ struct SignIn2FAView: View {
             
             HStack {
                 Spacer()
-                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode.length)
+                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode.length) {
+                    appState.submitSecurityCode(.device(code: $0), sessionData: sessionData)
+                }
                 Spacer()
             }
             .padding()

--- a/Xcodes/Frontend/SignIn/SignInSMSView.swift
+++ b/Xcodes/Frontend/SignIn/SignInSMSView.swift
@@ -15,7 +15,9 @@ struct SignInSMSView: View {
             
             HStack {
                 Spacer()
-                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode.length)
+                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode.length) {
+                    appState.submitSecurityCode(.sms(code: $0, phoneNumberId: trustedPhoneNumber.id), sessionData: sessionData)
+                }
                 Spacer()
             }
             .padding()


### PR DESCRIPTION
## Motivation

After entering last character, we need manually click the continue button.

We should follow how Apple is doing for their 2FA Service.

## Result

After entering last character, trigger the continue button automatically.

## Test

Run the Preview on PinCodeTextView.swift with Xcode 14.3

When entering last character check the "Previews log" console in Xcode.