### PR TITLE
Add installation progress bar to dock icon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run tests
       env:
-        DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
+        DEVELOPER_DIR: /Applications/Xcode_14.2.app
       run: xcodebuild test -scheme Xcodes

--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		E8E98A9025D8631800EC89A0 /* InstallationStepRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFBC3FF259AC17F00E2A3D8 /* InstallationStepRowView.swift */; };
 		E8E98A9625D863D700EC89A0 /* InstallationStepDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8E98A9525D863D700EC89A0 /* InstallationStepDetailView.swift */; };
 		E8F81FC4282D8A17006CBD0F /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = E8F81FC3282D8A17006CBD0F /* Sparkle */; };
+		E689540325BE8C64000EBCEA /* DockProgress in Frameworks */ = {isa = PBXBuildFile; productRef = E689540225BE8C64000EBCEA /* DockProgress */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -326,6 +327,7 @@
 				E8F81FC4282D8A17006CBD0F /* Sparkle in Frameworks */,
 				CABFA9E42592F08E00380FEE /* Version in Frameworks */,
 				CABFA9FD2592F13300380FEE /* LegibleError in Frameworks */,
+				E689540325BE8C64000EBCEA /* DockProgress in Frameworks */,
 				CA9FF86D25951C6E00E47BAF /* XCModel in Frameworks */,
 				CABFA9F82592F0F900380FEE /* KeychainAccess in Frameworks */,
 				CAA858CD25A3D8BC00ACF8C0 /* ErrorHandling in Frameworks */,
@@ -665,6 +667,7 @@
 				CA9FF86C25951C6E00E47BAF /* XCModel */,
 				CAA858CC25A3D8BC00ACF8C0 /* ErrorHandling */,
 				E8F81FC3282D8A17006CBD0F /* Sparkle */,
+				E689540225BE8C64000EBCEA /* DockProgress */,
 			);
 			productName = XcodesMac;
 			productReference = CAD2E79E2449574E00113D76 /* Xcodes.app */;
@@ -748,6 +751,7 @@
 				CAA858CB25A3D8BC00ACF8C0 /* XCRemoteSwiftPackageReference "ErrorHandling" */,
 				CAC28186259EE27200B8AB0B /* XCRemoteSwiftPackageReference "CombineExpectations" */,
 				E8F81FC2282D8A17006CBD0F /* XCRemoteSwiftPackageReference "Sparkle" */,
+				E689540125BE8C64000EBCEA /* XCRemoteSwiftPackageReference "DockProgress" */,
 			);
 			productRefGroup = CAD2E79F2449574E00113D76 /* Products */;
 			projectDirPath = "";
@@ -1475,6 +1479,14 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		E689540125BE8C64000EBCEA /* XCRemoteSwiftPackageReference "DockProgress" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/DockProgress";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1526,6 +1538,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E8F81FC2282D8A17006CBD0F /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		E689540225BE8C64000EBCEA /* DockProgress */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E689540125BE8C64000EBCEA /* XCRemoteSwiftPackageReference "DockProgress" */;
+			productName = DockProgress;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "DockProgress",
+        "repositoryURL": "https://github.com/sindresorhus/DockProgress",
+        "state": {
+          "branch": null,
+          "revision": "7100b68571e2dafe3a06ad5905b80fc3b0107b4b",
+          "version": "3.2.0"
+        }
+      },
+      {
         "package": "ErrorHandling",
         "repositoryURL": "https://github.com/RobotsAndPencils/ErrorHandling",
         "state": {

--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -5,6 +5,7 @@ import AppleAPI
 import Version
 import LegibleError
 import os.log
+import DockProgress
 
 /// Downloads and installs Xcodes
 extension AppState {
@@ -151,6 +152,7 @@ extension AppState {
             cookies
         )
         progressChanged(progress)
+        updateDockIcon(withProgress: progress)
         return publisher
             .map { _ in destination.url }
             .eraseToAnyPublisher()
@@ -160,11 +162,12 @@ extension AppState {
         let resumeDataPath = Path.xcodesApplicationSupport/"Xcode-\(availableXcode.version).resumedata"
         let persistedResumeData = Current.files.contents(atPath: resumeDataPath.string)
         
-        return attemptResumableTask(maximumRetryCount: 3) { resumeData -> AnyPublisher<URL, Error> in
+        return attemptResumableTask(maximumRetryCount: 3) { [weak self] resumeData -> AnyPublisher<URL, Error> in
             let (progress, publisher) = Current.network.downloadTask(with: availableXcode.url,
                                                                    to: destination.url,
                                                                    resumingWith: resumeData ?? persistedResumeData)
             progressChanged(progress)
+            self?.updateDockIcon(withProgress: progress)
             return publisher
                 .map { $0.saveLocation }
                 .eraseToAnyPublisher()
@@ -173,6 +176,11 @@ extension AppState {
             self.persistOrCleanUpResumeData(at: resumeDataPath, for: completion)
         })
         .eraseToAnyPublisher()
+    }
+    
+    private func updateDockIcon(withProgress progress: Progress) {
+        DockProgress.style = .bar
+        DockProgress.progressInstance = progress
     }
 
     public func installArchivedXcode(_ availableXcode: AvailableXcode, at archiveURL: URL) -> AnyPublisher<InstalledXcode, Error> {

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -107,6 +107,19 @@ class AppState: ObservableObject {
     private var selectPublisher: AnyCancellable?
     private var uninstallPublisher: AnyCancellable?
     private var autoInstallTimer: Timer?
+    
+    // MARK: - Dock Progress Tracking
+    
+    public static let totalProgressUnits = Int64(10)
+    public static let unxipProgressWeight = Int64(1)
+    var overallProgress = Progress()
+    var unxipProgress = {
+        let progress = Progress(totalUnitCount: totalProgressUnits)
+        progress.kind = .file
+        progress.fileOperationKind = .copying
+        return progress
+    }()
+    
     // MARK: - 
     
     var dataSource: DataSource {
@@ -491,8 +504,7 @@ class AppState: ObservableObject {
         // Cancel the publisher
         installationPublishers[id] = nil
         
-        // Remove dock icon progress indicator
-        DockProgress.progress = 1 // Only way to completely remove overlay with DockProgress is setting progress to complete
+        resetDockProgressTracking()
                 
         // If the download is cancelled by the user, clean up the download files that aria2 creates.
         // This isn't done as part of the publisher with handleEvents(receiveCancel:) because it shouldn't happen when e.g. the app quits.

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -7,6 +7,7 @@ import KeychainAccess
 import Path
 import Version
 import os.log
+import DockProgress
 
 class AppState: ObservableObject {
     private let client = AppleAPI.Client()
@@ -489,6 +490,9 @@ class AppState: ObservableObject {
 
         // Cancel the publisher
         installationPublishers[id] = nil
+        
+        // Remove dock icon progress indicator
+        DockProgress.progress = 1 // Only way to completely remove overlay with DockProgress is setting progress to complete
                 
         // If the download is cancelled by the user, clean up the download files that aria2 creates.
         // This isn't done as part of the publisher with handleEvents(receiveCancel:) because it shouldn't happen when e.g. the app quits.

--- a/Xcodes/Resources/Licenses.rtf
+++ b/Xcodes/Resources/Licenses.rtf
@@ -308,6 +308,21 @@ For more information, please refer to &lt;<http://unlicense.org/>&gt;\
     otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.\
 \
 
+\fs34 DockProgress\
+\
+
+\fs26 MIT License\
+\
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\
+\
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\
+\
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\
+\
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\
+\
+\
+
 \fs34 KeychainAccess\
 \
 


### PR DESCRIPTION
Closes #17

Uses suggested [DockProgress](https://github.com/sindresorhus/DockProgress) to display a progress bar overlay on top of the dock icon as an Xcode is downloading.

Successor to #85. A new `overallProgress` has been pulled up to track the downloading and the unarchive portion of installing an Xcode. Within the `overallProgress` the following weights are applied:

* 90% of the overall progress is allocated to the download
* The remaining 10% is allocated to the unarchive step
    * This is tracked in a binary fashion (incomplete or complete) as no progress is provided in any sort of callback during the unarchive process

Below are some previews:

### During download

<img width="928" alt="Screenshot 2023-09-14 at 13 06 35" src="https://github.com/XcodesOrg/XcodesApp/assets/818102/fe3ee8c3-79ce-4ff2-bdcc-68effbe3f0c0">

### During unarchiving

<img width="906" alt="Screenshot 2023-09-14 at 13 09 28" src="https://github.com/XcodesOrg/XcodesApp/assets/818102/be10a73e-eaf4-40b7-a8f3-7b551bd07353">

### During the post-installation/finishing steps

These final steps require user interaction so no new child `Progress` objects were created to track these. However, you can see that once it gets here, the progress bar is gone.

<img width="903" alt="Screenshot 2023-09-14 at 13 24 18" src="https://github.com/XcodesOrg/XcodesApp/assets/818102/df0089ec-bf5a-43e1-b89d-dd9222a96a79">

