### PR TITLE
Activity Indicator on Install Pressed

### DIFF
--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -34,16 +34,26 @@ struct XcodeCommands: Commands {
 
 struct InstallButton: View {
     @EnvironmentObject var appState: AppState
+    @State private var isLoading = false
+
     let xcode: Xcode?
-    
+
     var body: some View {
         Button(action: install) {
-            Text("Install")
-                .help("Install")
-        }
+            if isLoading {
+                ProgressView()
+                    .colorInvert()
+                    .controlSize(.small)
+            } else {
+                Text("Install")
+                    .textCase(.uppercase)
+                    .help("InstallDescription")
+            }
+        }.buttonStyle(AppStoreButtonStyle(primary: false, highlighted: false))
     }
-    
+
     private func install() {
+        isLoading = true
         guard let xcode = xcode else { return }
         appState.checkMinVersionAndInstall(id: xcode.id)
     }

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -43,9 +43,8 @@ struct InstallButton: View {
             install()
         } label: {
             Text("Install")
-                .textCase(.uppercase)
                 .help("InstallDescription")
-        }.buttonStyle(AppStoreButtonStyle(primary: false, highlighted: false))
+        }
     }
 
     private func install() {

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -39,16 +39,12 @@ struct InstallButton: View {
     let xcode: Xcode?
 
     var body: some View {
-        Button(action: install) {
-            if isLoading {
-                ProgressView()
-                    .colorInvert()
-                    .controlSize(.small)
-            } else {
-                Text("Install")
-                    .textCase(.uppercase)
-                    .help("InstallDescription")
-            }
+        ProgressButton(isInProgress: isLoading) {
+            install()
+        } label: {
+            Text("Install")
+                .textCase(.uppercase)
+                .help("InstallDescription")
         }.buttonStyle(AppStoreButtonStyle(primary: false, highlighted: false))
     }
 

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -110,10 +110,7 @@ struct XcodeListViewRow: View {
                 .buttonStyle(AppStoreButtonStyle(primary: true, highlighted: selected))
                 .help("OpenDescription")
         case .notInstalled:
-            Button("Install") { appState.checkMinVersionAndInstall(id: xcode.id) }
-                .textCase(.uppercase)
-                .buttonStyle(AppStoreButtonStyle(primary: false, highlighted: selected))
-                .help("InstallDescription")
+            InstallButton(xcode: xcode)
         case let .installing(installationStep):
             InstallationStepRowView(
                 installationStep: installationStep,

--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -111,6 +111,8 @@ struct XcodeListViewRow: View {
                 .help("OpenDescription")
         case .notInstalled:
             InstallButton(xcode: xcode)
+                .textCase(.uppercase)
+                .buttonStyle(AppStoreButtonStyle(primary: false, highlighted: false))
         case let .installing(installationStep):
             InstallationStepRowView(
                 installationStep: installationStep,


### PR DESCRIPTION
I noticed that there is often a long delay between clicking Install and the button switching to the linear progress view which sometimes makes it seem unresponsive. So I added a circular style progress view to the install button to indicate activity and reduce the chance of repeat clicks.

Before:
<img width="77" alt="Screenshot 2023-10-17 at 6 21 21 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/8951682/1f9aabab-4bf1-4fb3-b758-6f3f07b5be62">

After:
<img width="81" alt="Screenshot 2023-10-17 at 6 21 26 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/8951682/39fb9fbe-f63d-4ce3-a6dd-8a819dd03c38">

