### PR TITLE
fix: settings link on Sonoma not working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
       env:
-        DEVELOPER_DIR: /Applications/Xcode_14.2.app
+        DEVELOPER_DIR: /Applications/Xcode_15.0.1.app
       run: xcodebuild test -scheme Xcodes

--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -86,16 +86,23 @@ struct MainToolbarModifier: ViewModifier {
             .keyboardShortcut(KeyboardShortcut("i", modifiers: [.command, .option]))
             .help("InfoDescription")
             
-            Button(action: {
-                if #available(macOS 13, *) {
-                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-                } else {
-                    NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-                }   
-            }, label: {
-                Label("Preferences", systemImage: "gearshape")
-            })
-            .help("PreferencesDescription")
+            if #available(macOS 14, *) {
+                SettingsLink(label: {
+                    Label("Preferences", systemImage: "gearshape")
+                })
+                .help("PreferencesDescription")
+            } else {
+                Button(action: {
+                    if #available(macOS 13, *) {
+                        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                    } else {
+                        NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+                    }
+                }, label: {
+                    Label("Preferences", systemImage: "gearshape")
+                })
+                .help("PreferencesDescription")
+            }
             
             TextField("Search", text: $searchText)
                 .textFieldStyle(RoundedBorderTextFieldStyle())


### PR DESCRIPTION
This fixes the settings icon on Sonoma so it actually opens settings via the toolbar

Pick a lane Apple!