### PR TITLE
Descriptive error for login status code 412

### DIFF
--- a/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
@@ -180,6 +180,8 @@ public class Client {
                         return (data, urlResponse)
                     case 400, 401:
                         throw AuthenticationError.incorrectSecurityCode
+                    case 412:
+                        throw AuthenticationError.appleIDAndPrivacyAcknowledgementRequired
                     case let code:
                         throw AuthenticationError.badStatusCode(statusCode: code, data: data, response: urlResponse)
                     }


### PR DESCRIPTION
If status code 412 comes back for logging in an error is provided regarding Apple Acknowledgements however, the security code entry does not cover this case. This change simply re-uses the existing error to explain why login failed.

closes #331, closes #406, Closes #417,  closes #418, closes #438 closes #440