### PR TITLE
Add default phone number selection when there is only one

### DIFF
--- a/Xcodes/Frontend/SignIn/SignInPhoneListView.swift
+++ b/Xcodes/Frontend/SignIn/SignInPhoneListView.swift
@@ -16,6 +16,11 @@ struct SignInPhoneListView: View {
                 List(phoneNumbers, selection: $selectedPhoneNumberID) {
                     Text($0.numberWithDialCode)
                 }
+                .onAppear {
+                    if phoneNumbers.count == 1 {
+                        selectedPhoneNumberID = phoneNumbers.first?.id
+                    }
+                }
             } else {
                 AttributedText(
                     NSAttributedString(string: localizeString("NoTrustedPhones"))


### PR DESCRIPTION
When I only have one trusted phone number and see the number selection view, I often get confused since it is hard to distinguish a tappable section in the list without a row highlight.
This change will select a phone number as a default when only one option exists.

|Single phone number |Multiple phone number |
|-|-|
|<img width="406" alt="Screenshot 2023-12-20 at 0 44 13" src="https://github.com/XcodesOrg/XcodesApp/assets/20346613/e9b00853-76b6-4d60-a614-f56717224bfc">|<img width="406" alt="Screenshot 2023-12-20 at 0 43 32" src="https://github.com/XcodesOrg/XcodesApp/assets/20346613/44707196-a6eb-4322-a111-7a9796d65e68">|

|Single phone number with row selected |Multiple phone number with row selected |
|-|-|
|<img width="406" alt="Screenshot 2023-12-20 at 0 43 06" src="https://github.com/XcodesOrg/XcodesApp/assets/20346613/22f106b8-2b1e-4c02-b066-0c5ea19ff59f">|<img width="406" alt="Screenshot 2023-12-20 at 0 44 41" src="https://github.com/XcodesOrg/XcodesApp/assets/20346613/9dd9bc30-dbfa-4a93-9b06-7e47eb96be21">|