### PR TITLE
Handle preference alerts from the PlatformsListView

### DIFF
--- a/Xcodes/XcodesApp.swift
+++ b/Xcodes/XcodesApp.swift
@@ -81,6 +81,9 @@ struct XcodesApp: App {
         Window("Platforms", id: "platforms") {
             PlatformsListView()
                 .environmentObject(appState)
+                .alert(item: $appState.presentedPreferenceAlert, content: { presentedAlert in
+                    alert(for: presentedAlert)
+                })
         }
 #endif
     }


### PR DESCRIPTION
The expected alert when choosing to delete a platform was not appearing. If I opened the `PreferencesView` and moved it off to the side I can see the alert appear over it when clicking the delete button. After adding this change I was able to see the alert in the `PlatformsListView`.

### Before:
<img width="1226" alt="Screenshot 2024-01-04 at 10 07 14 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/8951682/66df5868-c70b-45a4-807f-6f6131937a6e">


### After:
<img width="1003" alt="Screenshot 2024-01-04 at 10 06 20 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/8951682/9bc5807c-8486-4699-b87f-7fc7186aa6de">
