### PR TITLE
Remove newline from derived data path returned by defaults

### DIFF
--- a/Xcodes/AcknowledgementsGenerator/Sources/AcknowledgementsGenerator/Tools/Xcode.swift
+++ b/Xcodes/AcknowledgementsGenerator/Sources/AcknowledgementsGenerator/Tools/Xcode.swift
@@ -35,7 +35,7 @@ private extension Xcode {
         try? task.run()
         let handle = pipe.fileHandleForReading
         let data = handle.readDataToEndOfFile()
-        let path = String(data: data, encoding: String.Encoding.utf8)
+        let path = String(data: data, encoding: String.Encoding.utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
         return (path?.isEmpty ?? true) ? nil : path
     }
 }


### PR DESCRIPTION
When reading the output from the defaults command invocation, we need to remove the trailing newline. Otherwise, the path will not resolve correctly.