### PR TITLE
Add Sponsor/Donate Button

### DIFF
--- a/Xcodes/Frontend/About/AboutView.swift
+++ b/Xcodes/Frontend/About/AboutView.swift
@@ -45,9 +45,18 @@ struct AboutView: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                 }
-                
-                Text(Bundle.main.humanReadableCopyright!)
-                    .font(.footnote)
+                HStack {
+                    Text(Bundle.main.humanReadableCopyright!)
+                        .font(.footnote)
+                    Button(action: {
+                        openURL(URL(string: "https://opencollective.com/xcodesapp")!)
+                    }) {
+                        HStack {
+                            Image(systemName: "heart.circle")
+                            Text("SponsorXcodes")
+                        }
+                    }
+                }
             }
         }
         .padding()

--- a/Xcodes/Frontend/XcodeList/BottomStatusBar.swift
+++ b/Xcodes/Frontend/XcodeList/BottomStatusBar.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct BottomStatusModifier: ViewModifier {
     @EnvironmentObject var appState: AppState
+    @SwiftUI.Environment(\.openURL) var openURL: OpenURLAction
     
     func body(content: Content) -> some View {
         VStack(spacing: 0) {
@@ -21,6 +22,14 @@ struct BottomStatusModifier: ViewModifier {
                     Text(appState.bottomStatusBarMessage)
                         .font(.subheadline)
                     Spacer()
+                    Button(action: {
+                        openURL(URL(string: "https://opencollective.com/xcodesapp")!)
+                    }) {
+                        HStack {
+                            Image(systemName: "heart.circle")
+                            Text("SponsorXcodes")
+                        }
+                    }
                     Text(Bundle.main.shortVersion!)
                         .font(.subheadline)
                 }

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -17251,6 +17251,9 @@
         }
       }
     },
+    "SponsorXcodes" : {
+      "extractionState" : "manual"
+    },
     "StopInstallation" : {
       "localizations" : {
         "ca" : {


### PR DESCRIPTION
Added the ability to sponsor/donate to Xcodes via the OpenSource Collective https://opencollective.com/xcodesapp
<img width="283" alt="Screenshot 2024-01-19 at 3 38 14 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/1119565/e6fe543d-b8d1-47b3-9396-3e6e357552c5">

No requirement what so ever!

Closes https://github.com/XcodesOrg/XcodesApp/issues/273