### PR TITLE
fix: adds back in sidebar toggle button so users don't get stuck

### DIFF
--- a/Xcodes/Frontend/Common/NavigationSplitViewWrapper.swift
+++ b/Xcodes/Frontend/Common/NavigationSplitViewWrapper.swift
@@ -26,18 +26,20 @@ struct NavigationSplitViewWrapper<Sidebar, Detail>: View where Sidebar: View, De
                 
                 if #available(macOS 14, *) {
                     sidebar
-                        .toolbar(removing: .sidebarToggle)
+                        .navigationSplitViewColumnWidth(min: 250, ideal: 300)
                 } else {
                     sidebar
                 }
             } detail: {
                 detail
             }
+            .navigationSplitViewStyle(.balanced)
         } else {
             // Alternative code for earlier versions of OS.
             NavigationView {
                 // The first column is the sidebar.
                 sidebar
+                    .frame(minWidth: 250)
                 detail
             }
             .navigationViewStyle(.columns)

--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -20,7 +20,6 @@ struct MainWindow: View {
     var body: some View {
         NavigationSplitViewWrapper {
             XcodeListView(selectedXcodeID: $selectedXcodeID, searchText: searchText, category: category, isInstalledOnly: isInstalledOnly)
-                .frame(minWidth: 250)
                 .layoutPriority(1)
                 .alert(item: $appState.xcodeBeingConfirmedForUninstallation) { xcode in
                     Alert(title: Text(String(format: localizeString("Alert.Uninstall.Title"), xcode.description)),


### PR DESCRIPTION
Adds back in the left side toggle. Users could drag the left sidebar all the way, hidding it, but there was no way to return it back. 

Closes #498 

![Screenshot 2024-02-06 at 10 06 19 PM](https://github.com/XcodesOrg/XcodesApp/assets/1119565/e4064b0e-b034-4204-bf4e-4a6d8a396b57)
