### PR TITLE
l10n(zh-Hant): Update translation for 2.0.2

### DIFF
--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -8,12 +8,24 @@
             "state" : "translated",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
         }
       }
     },
     "%@" : {
       "localizations" : {
         "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@"
@@ -34,12 +46,24 @@
             "state" : "translated",
             "value" : "%1$@ %2$@ %3$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %2$@ %3$@"
+          }
         }
       }
     },
     "• %@" : {
       "localizations" : {
         "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "• %@"
@@ -479,7 +503,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "啟用中"
+            "value" : "已啟用"
           }
         }
       }
@@ -698,7 +722,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "這是啟用中版本"
+            "value" : "這個版本已經啟用"
           }
         }
       }
@@ -917,7 +941,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "所有已進行的安裝步驟將被放棄。"
+            "value" : "將放棄既有進度。"
           }
         }
       }
@@ -1055,6 +1079,12 @@
             "state" : "translated",
             "value" : "Xcode %@ sürümünü yüklemeyi durdurmak istediğine emin misin?"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你確定要停止安裝 Xcode %@ 嗎？"
+          }
         }
       }
     },
@@ -1167,7 +1197,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "你確定你想要停止安裝 Xcode %@？"
+            "value" : "你確定要停止安裝 Xcode %@ 嗎？"
           }
         }
       }
@@ -1186,6 +1216,12 @@
             "state" : "translated",
             "value" : "Supprimer"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
         }
       }
     },
@@ -1202,6 +1238,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Êtes-vous sûr de vouloir supprimer %@ ?"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你確定要刪除 %@ 嗎？"
           }
         }
       }
@@ -2333,7 +2375,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Xcode.app 已經存在，但並不是一個 Symlink"
+            "value" : "Xcode.app 已經存在，而且不是符號連結"
           }
         }
       }
@@ -2447,7 +2489,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "無法建立 Symlink"
+            "value" : "無法建立符號連結"
           }
         }
       }
@@ -2495,6 +2537,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法找到文件\"%@\"."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到「%@」檔案。"
           }
         }
       }
@@ -2719,7 +2767,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "它將會被移到垃圾桶，但不會被清除。"
+            "value" : "將移到垃圾桶，但垃圾桶不會清空。"
           }
         }
       }
@@ -3065,6 +3113,12 @@
             "state" : "translated",
             "value" : "Apple Silikon"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Silicon"
+          }
         }
       }
     },
@@ -3399,7 +3453,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自動建立 Symlink 至 Xcode.app"
+            "value" : "自動建立連接到 Xcode.app 的符號連結"
           }
         }
       }
@@ -3511,7 +3565,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "當你選擇/啟用一個 Xcode 版本，自動建立一個名為 Xcode.app 的 Symlink 到該版本的安裝目錄"
+            "value" : "選擇或啟用一個 Xcode 版本時，自動建立一個名為 Xcode.app 的符號連結到該版本的安裝目錄"
           }
         }
       }
@@ -3848,7 +3902,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只看測試版"
+            "value" : "只顯示測試版"
           }
         }
       }
@@ -4060,7 +4114,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "變更"
+            "value" : "更改"
           }
         }
       }
@@ -5027,7 +5081,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "複製 URL"
+            "value" : "拷貝 URL"
           }
         }
       }
@@ -5139,7 +5193,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "製作 Xcode-Beta.app 的 Symlink"
+            "value" : "製作 Xcode.app 符號連結"
           }
         }
       }
@@ -5228,6 +5282,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "以Xcode-Beta.app创建软链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "製作 Xcode-Beta.app 符號連結"
           }
         }
       }
@@ -6570,6 +6630,12 @@
             "state" : "translated",
             "value" : "Erreur"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錯誤"
+          }
         }
       }
     },
@@ -6579,6 +6645,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ornek@icloud.com"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "example@icloud.com"
           }
         }
       }
@@ -7927,6 +7999,12 @@
             "state" : "translated",
             "value" : "Gizli"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏"
+          }
         }
       }
     },
@@ -8150,7 +8228,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "有時候預先發行版與正式版的建制版本號會相同，Xcodes 會自動將這些版本整理在一起。"
+            "value" : "有時候預先發行版與正式版的建置版本號會相同，Xcodes 會自動將這些版本整理在一起。"
           }
         }
       }
@@ -8619,6 +8697,12 @@
             "state" : "translated",
             "value" : "YÜKLE"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝"
+          }
         }
       }
     },
@@ -8844,7 +8928,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "壓縮檔 \"%@\" 已經損壞並無法解壓縮。"
+            "value" : "壓縮檔「%@」已經損壞並無法解壓縮。"
           }
         }
       }
@@ -9748,7 +9832,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "壓縮檔 \"%@\" 由於缺乏足夠的磁碟空間，無法解壓縮。\n\n請清空更多磁碟空間以確保可以解壓縮該檔案，然後再重新安裝 Xcode %@ 一次。安裝步驟將會從上次停住的地方繼續。"
+            "value" : "壓縮檔「%@」由於缺乏足夠的磁碟空間，無法解壓縮。\n\n請清空更多磁碟空間以確保可以解壓縮該檔案，然後再重新安裝 Xcode %@ 一次。安裝步驟將會從上次停住的地方繼續。"
           }
         }
       }
@@ -10426,7 +10510,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ 已經安裝於 %@"
+            "value" : "%@ 已經在 %@ 安裝"
           }
         }
       }
@@ -10539,7 +10623,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ 沒有被安裝。"
+            "value" : "%@ 尚未安裝。"
           }
         }
       }
@@ -10837,6 +10921,12 @@
             "state" : "translated",
             "value" : "安装目录"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝目錄"
+          }
         }
       }
     },
@@ -11012,6 +11102,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xcodes会在一个目录中检索及安装。默认（推荐）保持/Applications。任何对Xcode存储位置的变更都可能会导致其他App或服务停止工作。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xcodes 搜尋並安裝軟體到這一個路徑。預設值是 /Applications（也不建議改動）。更改 Xcode 的安裝位置可能導致其他應用程式或服務停止運作。"
           }
         }
       }
@@ -11230,7 +11326,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "軟體許可證"
+            "value" : "授權條款"
           }
         }
       }
@@ -13034,6 +13130,12 @@
             "state" : "translated",
             "value" : "Gizli Değil"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未隱藏"
+          }
         }
       }
     },
@@ -13929,7 +14031,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "沒有已選取的 Xcode"
+            "value" : "未選取 Xcode"
           }
         }
       }
@@ -14041,6 +14143,12 @@
             "state" : "translated",
             "value" : "OnSelect"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OnSelect"
+          }
         }
       }
     },
@@ -14118,6 +14226,12 @@
             "state" : "translated",
             "value" : "保持名称为Xcode-X.X.X.app"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留 Xcode-X.X.X.app 名稱"
+          }
         }
       }
     },
@@ -14189,6 +14303,12 @@
             "state" : "translated",
             "value" : "选中时，将会保持各版本的名称。例如Xcode-13.4.1.app。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇時，會保留有版本的檔名，如 Xcode-13.4.1.app"
+          }
         }
       }
     },
@@ -14253,6 +14373,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "总是重命名为Xcode.app"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "總是重新命名為 Xcode.app"
           }
         }
       }
@@ -14324,6 +14450,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选中时，会自动尝试重命名活跃的Xcode为Xcode.app，将之前的Xcode.app重命名为包含版本的名称。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇時，會自動嘗試將目前啟用的 Xcode 重新命名為 Xcode.app，而將先前的 Xcode.app 重新命名為有版本的檔名。"
           }
         }
       }
@@ -14447,6 +14579,12 @@
             "state" : "translated",
             "value" : "AÇ"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打開"
+          }
         }
       }
     },
@@ -14462,6 +14600,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rosetta ile Aç"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Rosetta 打開"
           }
         }
       }
@@ -14703,6 +14847,12 @@
             "state" : "translated",
             "value" : "Yükleme sonrası adımları uygula"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行安裝後步驟"
+          }
         }
       }
     },
@@ -14712,6 +14862,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Platformlar"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平台"
           }
         }
       }
@@ -14729,6 +14885,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ci-dessous une liste des plateformes installées sur cette machine."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下列是本機器安裝的平台名單。"
           }
         }
       }
@@ -15950,7 +16112,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "只看正式版"
+            "value" : "只顯示正式版"
           }
         }
       }
@@ -16168,7 +16330,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "顯示於 Finder"
+            "value" : "在 Finder 中顯示"
           }
         }
       }
@@ -16274,7 +16436,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SDKs"
+            "value" : "SDK 清單"
           }
         }
       }
@@ -16985,6 +17147,12 @@
             "state" : "translated",
             "value" : "显示“在Rosetta中打开”选项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示「使用 Rosetta 打開」選項"
+          }
         }
       }
     },
@@ -17030,6 +17198,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“在Rosetta中打开”将会在有其他“打开”方式可用时显示。注：此选项只会在Apple Silicon设备上显示。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「使用 Rosetta 打開」選項會在「打開」選項所在的區塊顯示。注意：這個選項只會在 Apple Silicon 機器顯示。"
           }
         }
       }
@@ -17254,7 +17428,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "登入您的Apple ID"
+            "value" : "使用您的 Apple ID 登入。"
           }
         }
       }
@@ -17490,6 +17664,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Support Xcodes"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持 Xcodes"
           }
         }
       }
@@ -18596,12 +18776,24 @@
             "state" : "translated",
             "value" : "👨🏻‍💻👩🏼‍💻 Happy WWDC %@! 👨🏽‍💻🧑🏻‍💻"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "👨🏻‍💻👩🏼‍💻 慶祝 WWDC %@！👨🏽‍💻🧑🏻‍💻"
+          }
         }
       }
     },
     "Xcode" : {
       "localizations" : {
         "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xcode"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xcode"
@@ -18616,11 +18808,24 @@
             "state" : "translated",
             "value" : "Xcodes"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xcodes"
+          }
         }
       }
     },
     "XCODES RULES!" : {
-
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "XCODES RULES!"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"


### PR DESCRIPTION
This PR completes the translation of zh-Hant (100%), unifies the terms (such as '拷貝'), and reviews the current translation.

r? @itszero @toto6038 [done]