### PR TITLE
Allow selecting text for version info

### DIFF
--- a/Xcodes/Frontend/InfoPane/CompilersView.swift
+++ b/Xcodes/Frontend/InfoPane/CompilersView.swift
@@ -16,7 +16,9 @@ struct CompilersView: View {
         if let compilers = compilers {
             VStack(alignment: .leading) {
                 Text("Compilers").font(.headline)
-                Text(Self.content(from: compilers)).font(.subheadline)
+                Text(Self.content(from: compilers))
+                    .font(.subheadline)
+                    .textSelection(.enabled)
             }
         } else {
             EmptyView()

--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -19,6 +19,7 @@ struct InfoPane: View {
                             Text(verbatim: "Xcode \(xcode.description) \(xcode.version.buildMetadataIdentifiersDisplay)")
                                 .font(.title)
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                                .textSelection(.enabled)
                         }
                         InfoPaneControls(xcode: xcode)
                     }

--- a/Xcodes/Frontend/InfoPane/SDKsView.swift
+++ b/Xcodes/Frontend/InfoPane/SDKsView.swift
@@ -18,7 +18,9 @@ struct SDKsView: View {
         } else {
             VStack(alignment: .leading) {
                 Text("SDKs").font(.headline)
-                Text(content).font(.subheadline)
+                Text(content)
+                    .font(.subheadline)
+                    .textSelection(.enabled)
             }
         }
     }


### PR DESCRIPTION
Allows selecting text from:
- Xcode Info header
- Compilers view
- SDKs view

