### PR TITLE
Center vertically Xcode version string in XcodeListViewRow

### DIFF
--- a/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListViewRow.swift
@@ -30,9 +30,6 @@ struct XcodeListViewRow: View {
                     Text(verbatim: path.string)
                         .font(.caption)
                         .foregroundColor(.secondary)
-                } else {
-                    Text(verbatim: "")
-                        .font(.caption)
                 }
             }
 


### PR DESCRIPTION
Very small PR with a slight visual tweak centering vertically the content in `XcodeListView` when Xcode isn't installed.

_Preview:_

<img width="452" alt="Xcodes_XcodeListView_tweak" src="https://github.com/XcodesOrg/XcodesApp/assets/554711/3c790856-1319-4cfb-bec3-1f0c73d34f72">
