### PR TITLE
Improve signing experience when using non-english keyboard

### DIFF
--- a/Xcodes/Frontend/SignIn/SignInCredentialsView.swift
+++ b/Xcodes/Frontend/SignIn/SignInCredentialsView.swift
@@ -1,9 +1,14 @@
 import SwiftUI
 
 struct SignInCredentialsView: View {
+    private enum FocusedField {
+        case username, password
+    }
+    
     @EnvironmentObject var appState: AppState
     @State private var username: String = ""
     @State private var password: String = ""
+    @FocusState private var focusedField: FocusedField?
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -16,11 +21,13 @@ struct SignInCredentialsView: View {
                 TextField(text: $username) {
                     Text(verbatim: "example@icloud.com")
                 }
+                .focused($focusedField, equals: .username)
             }
             HStack {
                 Text("Password")
                     .frame(minWidth: 100, alignment: .trailing)
                 SecureField("Required", text: $password)
+                    .focused($focusedField, equals: .password)
             }
             if appState.authError != nil {
                 HStack {


### PR DESCRIPTION
## Context

Sometimes, we can not type password when we forgot to switch back to English keyboard.

## Fix

It may related to a focus issue, so I added a `.focused` modifier to resolve the issue.

I think that might because when `SecurityField` gets focus, it automatically switches to English while in process, `SecurityField` loses the focus ( not sure why ). 

By implementing the fix, it works correctly in any situation.

## Comparison 

Here is a comparison video for you to checkout what I have resolved.

https://github.com/XcodesOrg/XcodesApp/assets/37542129/ddca0d7b-aec3-40d0-a8c3-1b2cef3e8800

