### PR TITLE
Resolve concurrency check warning on Swift 5.10

### DIFF
--- a/Xcodes/Backend/Environment.swift
+++ b/Xcodes/Backend/Environment.swift
@@ -116,7 +116,8 @@ public struct Shell {
         return AsyncThrowingStream<Progress, Error> { continuation in
  
             Task {
-                var progress = Progress()
+                // Assume progress will not have data races, so we manually opt-out isolation checks.
+                nonisolated(unsafe) var progress = Progress()
                 progress.kind = .file
                 progress.fileOperationKind = .downloading
                 


### PR DESCRIPTION
Swift 5.10 introduces stricter concurrency check which adds one more warning **`Reference to captured var 'progress' in concurrently-executing code; this is an error in Swift 6`**.

Because progress update is based on Notification and **operates on `OperationQueue.main`**, so we don't need to worry about data races.

So I opt-out concurrency check here by using `nonisolated(unsafe)`