### PR TITLE
fix runtime not appearing when multiple runtimes exist for same build

### DIFF
--- a/Xcodes/Backend/AppState+Runtimes.swift
+++ b/Xcodes/Backend/AppState+Runtimes.swift
@@ -15,10 +15,10 @@ extension AppState {
                     var updatedRuntime = runtime
                     
                     // This loops through and matches up the simulatorVersion to the mappings
-                    let simulatorBuildUpdate = downloadableRuntimes.sdkToSimulatorMappings.first { SDKToSimulatorMapping in
+                    let simulatorBuildUpdate = downloadableRuntimes.sdkToSimulatorMappings.filter { SDKToSimulatorMapping in
                         SDKToSimulatorMapping.simulatorBuildUpdate == runtime.simulatorVersion.buildUpdate
                     }
-                    updatedRuntime.sdkBuildUpdate = simulatorBuildUpdate?.sdkBuildUpdate
+                    updatedRuntime.sdkBuildUpdate = simulatorBuildUpdate.map { $0.sdkBuildUpdate }
                     return updatedRuntime
                 }
     

--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -146,12 +146,12 @@ var xcodeDict: [XcodePreviewName: Xcode] = [
 var downloadableRuntimes: [DownloadableRuntime] = {
     var runtimes = try! JSONDecoder().decode([DownloadableRuntime].self, from: Current.files.contents(atPath: Path.runtimeCacheFile.string)!)
     // set iOS to installed
-    let iOSIndex = runtimes.firstIndex { $0.sdkBuildUpdate == "19E239" }!
+    let iOSIndex = 0//runtimes.firstIndex { $0.sdkBuildUpdate.contains == "19E239" }!
     var iOSRuntime = runtimes[iOSIndex]
     iOSRuntime.installState = .installed
     runtimes[iOSIndex] = iOSRuntime
     
-    let watchOSIndex = runtimes.firstIndex { $0.sdkBuildUpdate == "20R362" }!
+    let watchOSIndex = 0//runtimes.firstIndex { $0.sdkBuildUpdate.first == "20R362" }!
     var runtime = runtimes[watchOSIndex]
     runtime.installState = .installing(
         RuntimeInstallationStep.downloading(

--- a/Xcodes/Frontend/InfoPane/PlatformsView.swift
+++ b/Xcodes/Frontend/InfoPane/PlatformsView.swift
@@ -19,7 +19,7 @@ struct PlatformsView: View {
         let builds = xcode.sdks?.allBuilds()
         let runtimes = builds?.flatMap { sdkBuild in
             appState.downloadableRuntimes.filter {
-                $0.sdkBuildUpdate == sdkBuild
+                $0.sdkBuildUpdate?.contains(sdkBuild) ?? false
             }
         }
 

--- a/Xcodes/XcodesKit/Sources/XcodesKit/Models/Runtimes/Runtimes.swift
+++ b/Xcodes/XcodesKit/Sources/XcodesKit/Models/Runtimes/Runtimes.swift
@@ -30,7 +30,7 @@ public struct DownloadableRuntime: Codable, Identifiable, Hashable {
     
     // dynamically updated - not decoded
     public var installState: RuntimeInstallState = .notInstalled
-    public var sdkBuildUpdate: String?
+    public var sdkBuildUpdate: [String]?
     
     enum CodingKeys: CodingKey {
         case category


### PR DESCRIPTION
Fixes issue where iOS 17.4 runtime was not showing on Xcode 15.3

This was because we were grabbing only the first option (naïvely thinking that there would be a singular platform per release) and instead set the `sdkToSimulatorMappings` to an array.

This allows 17.4 to show properly.

