### PR TITLE
Release notes button isn't obvious

### DIFF
--- a/Xcodes/Frontend/InfoPane/ReleaseDateView.swift
+++ b/Xcodes/Frontend/InfoPane/ReleaseDateView.swift
@@ -15,18 +15,16 @@ struct ReleaseDateView: View {
         if let date = date {
            
                 VStack(alignment: .leading) {
-                    HStack {
-                        Text("ReleaseDate")
-                            .font(.headline)
-                        Spacer()
-                        if let url {
-                            ReleaseNotesView(url: url)
-                        }
-                    }
+                    Text("ReleaseDate")
+                        .font(.headline)
                     
                     Text("\(date, style: .date)")
                         .font(.subheadline)
                   
+                    if let url {
+                        ReleaseNotesView(url: url)
+                            .padding(.top, 2)
+                    }
                 }
                 
            

--- a/Xcodes/Frontend/InfoPane/ReleaseNotesView.swift
+++ b/Xcodes/Frontend/InfoPane/ReleaseNotesView.swift
@@ -16,10 +16,9 @@ struct ReleaseNotesView: View {
     var body: some View {
         if let url = url {
             Button(action: { openURL(url) }) {
-                Image(systemName: "link.circle.fill")
-                    .font(.title)
+                Text("ReleaseNotes")
+                    .font(.callout)
             }
-            .buttonStyle(.plain)
             .contextMenu(menuItems: {
                 CopyReleaseNoteButton(url: url)
             })

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -16518,10 +16518,52 @@
     },
     "ReleaseNotes" : {
       "localizations" : {
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes de la versió"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release-Notes"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Release Notes"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notas del Lanzamiento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notes de Mise á Jour"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note di Rilascio"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release Notes"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notas de Lançamento"
           }
         }
       }

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -16516,6 +16516,16 @@
         }
       }
     },
+    "ReleaseNotes" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release Notes"
+          }
+        }
+      }
+    },
     "ReleaseNotes.help" : {
       "localizations" : {
         "ca" : {


### PR DESCRIPTION
I wanted to see the release notes for Xcode 15.3 but I didn't see a button in the info pane, so this being an open source project I forked the repo to add a button.

Then when I looked at the code I realized the 🔗 button _is_ the release notes button I was planning on adding.

Now I know what the button does, but I obviously didn't understand it at first glance, and I didn't hover long enough to see the help tip either. So instead of adding a Release Notes button this PR replaces the 🔗 with text, to make it more discoverable

I don't know if this is the best solution, but I thought I'd share the idea and see what you think.
This approach also adds one more string to localize. I was able to copy out the pertinent bit of the ReleaseNotes.help string for a few of the romantic and germanic languages, but there are a few others left to do. I could look into doing those too if we decide to move forward with the text idea. (Or just use the help text directly, including the "see" part and not add a new string at all.)

PR
<img width="207" alt="Screenshot 2024-03-08 at 1 24 37 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/12513211/5ffbc481-2442-4584-ba7c-662a1eb0b9cd">

Released
<img width="217" alt="Screenshot 2024-03-08 at 1 25 32 PM" src="https://github.com/XcodesOrg/XcodesApp/assets/12513211/747d199f-e948-41a6-ad90-cbca866b0fc8">