### PR TITLE
Trailing Icon for Filter Button

### DIFF
--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B0C6AD042AD6E65700E64698 /* ReleaseDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C6AD032AD6E65700E64698 /* ReleaseDateView.swift */; };
 		B0C6AD0B2AD9178E00E64698 /* IdenticalBuildView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C6AD0A2AD9178E00E64698 /* IdenticalBuildView.swift */; };
 		B0C6AD0D2AD91D7900E64698 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C6AD0C2AD91D7900E64698 /* IconView.swift */; };
+		BDBAB7452B9FF55800694B0B /* TrailingIconLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBAB7442B9FF55800694B0B /* TrailingIconLabelStyle.swift */; };
 		CA11E7BA2598476C00D2EE1C /* XcodeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E7B92598476C00D2EE1C /* XcodeCommands.swift */; };
 		CA2518EC25A7FF2B00F08414 /* AppStateUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2518EB25A7FF2B00F08414 /* AppStateUpdateTests.swift */; };
 		CA25192A25A9644800F08414 /* XcodeInstallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25192925A9644800F08414 /* XcodeInstallState.swift */; };
@@ -209,6 +210,7 @@
 		B0C6AD032AD6E65700E64698 /* ReleaseDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseDateView.swift; sourceTree = "<group>"; };
 		B0C6AD0A2AD9178E00E64698 /* IdenticalBuildView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdenticalBuildView.swift; sourceTree = "<group>"; };
 		B0C6AD0C2AD91D7900E64698 /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
+		BDBAB7442B9FF55800694B0B /* TrailingIconLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrailingIconLabelStyle.swift; sourceTree = "<group>"; };
 		CA11E7B92598476C00D2EE1C /* XcodeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeCommands.swift; sourceTree = "<group>"; };
 		CA2518EB25A7FF2B00F08414 /* AppStateUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateUpdateTests.swift; sourceTree = "<group>"; };
 		CA25192925A9644800F08414 /* XcodeInstallState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeInstallState.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 				536CFDD3263C9A8000026CE0 /* XcodesSheet.swift */,
 				53CBAB2B263DCC9100410495 /* XcodesAlert.swift */,
 				E84B7D0C2B296A8900DBDA2B /* NavigationSplitViewWrapper.swift */,
+				BDBAB7442B9FF55800694B0B /* TrailingIconLabelStyle.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -919,6 +922,7 @@
 				CA9FF84E2595079F00E47BAF /* ScrollingTextView.swift in Sources */,
 				E832EAF82B0FBCF4001B570D /* RuntimeInstallationStepDetailView.swift in Sources */,
 				CABFA9C12592EEEA00380FEE /* Version+.swift in Sources */,
+				BDBAB7452B9FF55800694B0B /* TrailingIconLabelStyle.swift in Sources */,
 				E8D655C0288DD04700A139C2 /* SelectedActionType.swift in Sources */,
 				36741BFD291E4FDB00A85AAE /* DownloadPreferencePane.swift in Sources */,
 				E84E4F542B333864003F3959 /* PlatformsListView.swift in Sources */,

--- a/Xcodes/Frontend/Common/TrailingIconLabelStyle.swift
+++ b/Xcodes/Frontend/Common/TrailingIconLabelStyle.swift
@@ -1,0 +1,22 @@
+//
+//  TrailingIconLabelStyle.swift
+//  Xcodes
+//
+//  Created by Daniel Chick on 3/11/24.
+//  Copyright © 2024 Robots and Pencils. All rights reserved.
+//
+
+import SwiftUI
+
+struct TrailingIconLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration.title
+            configuration.icon
+        }
+    }
+}
+
+extension LabelStyle where Self == TrailingIconLabelStyle {
+    static var trailingIcon: Self { Self() }
+}

--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -34,25 +34,13 @@ struct MainToolbarModifier: ViewModifier {
                 case .all:
                     Label("All", systemImage: "line.horizontal.3.decrease.circle")
                 case .release:
-                    if #available(macOS 11.3, *) {
                         Label("ReleaseOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
-                            .labelStyle(TitleAndIconLabelStyle())
+                            .labelStyle(.trailingIcon)
                             .foregroundColor(.accentColor)
-                    } else {
-                        Label("ReleaseOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
-                            .labelStyle(TitleOnlyLabelStyle())
-                            .foregroundColor(.accentColor)
-                    }
                 case .beta:
-                    if #available(macOS 11.3, *) {
-                        Label("BetaOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
-                            .labelStyle(TitleAndIconLabelStyle())
-                            .foregroundColor(.accentColor)
-                    } else {
-                        Label("BetaOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
-                            .labelStyle(TitleOnlyLabelStyle())
-                            .foregroundColor(.accentColor)
-                    }
+                    Label("BetaOnly", systemImage: "line.horizontal.3.decrease.circle.fill")
+                        .labelStyle(.trailingIcon)
+                        .foregroundColor(.accentColor)
                 }
             }
             .help("FilterAvailableDescription")


### PR DESCRIPTION
The label icon for the Xcode release filter jumped around when the filter was changed. This PR creates a new style that makes the icon trailing so that it stays in one place as the text changes.

### old:
![old](https://github.com/XcodesOrg/XcodesApp/assets/8951682/0ffbd426-b89e-4183-82bf-c101dbd335cf)

### new:
![No Xcode Selected](https://github.com/XcodesOrg/XcodesApp/assets/8951682/7ba4e397-6516-4d77-baf1-6cf884263599)
