### PR TITLE
fix: sidebar missing text on MacOS 14.4

### DIFF
--- a/Xcodes/Frontend/XcodeList/XcodeListView.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListView.swift
@@ -65,7 +65,7 @@ struct PlatformsPocket: View {
                 Text("PlatformsDescription")
             }
             .font(.body.weight(.medium))
-            .padding(.horizontal)
+            .padding(.horizontal, 7) // this can't be > 8 or nil or it messes up the entire sidebar - https://github.com/XcodesOrg/XcodesApp/issues/534 Go ahead - you do you SwiftUI!
             .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(.quaternary.opacity(0.75))


### PR DESCRIPTION
LOL. I love SwiftUI sometimes!

Fixes #534 

| Padding > 7 or nil | Other values |
|--------|--------|
| ![DUqCkUf5h1L2y9ZE4hxnJ87a](https://github.com/XcodesOrg/XcodesApp/assets/1119565/324fc5ab-41f5-435e-8468-6d56b34dd08f) | ![vTTmKEEyTRdlLrzfp8elDeoR](https://github.com/XcodesOrg/XcodesApp/assets/1119565/6b1cce84-913a-4fd8-a30f-bb2a74e4ecd9) | 



