### PR TITLE
fix: xcode list row text hidden on macOS 14.4

### DIFF
--- a/Xcodes/Frontend/XcodeList/XcodeListView.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListView.swift
@@ -63,11 +63,11 @@ struct PlatformsPocket: View {
                 Image(systemName: "square.3.layers.3d")
                     .font(.title3.weight(.medium))
                 Text("PlatformsDescription")
+								Spacer()
             }
             .font(.body.weight(.medium))
             .padding(.horizontal)
             .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
             .background(.quaternary.opacity(0.75))
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }


### PR DESCRIPTION
fixed #537
seems there is a pull request (#535) fixed this bug, but I think this PR is a more reasonable way to have this fixed instead of have a padding less than 8

@MattKiazyk and thanks for the quick responding!

another tip: while I try update the list using `ScrollView` + `LazyVStack` + `ForEach` should be ok compare to using `List` directly, but this will cause more unexpected error like the context menu only triggerred on the text area, so I think may be this  should be an optimization in the future

### Before
<img width="1249" alt="Screenshot 2024-03-17 at 20 51 04" src="https://github.com/XcodesOrg/XcodesApp/assets/24761186/39827a29-ad3a-4163-bc8e-7820d044dcd3">
### After
<img width="1249" alt="Screenshot 2024-03-17 at 20 50 56" src="https://github.com/XcodesOrg/XcodesApp/assets/24761186/cb773227-b761-4de1-ac00-512b60249921">