### PR TITLE
Adds margins to InfoPannel for older OS

### DIFF
--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -8,17 +8,8 @@ import struct XCModel.SDKs
 
 struct InfoPane: View {
     let xcode: Xcode
-    var body: some View {
-        if #available(macOS 14.0, *) {
-            mainContent
-                .contentMargins(10, for: .scrollContent)
-        } else {
-            mainContent
-                .padding()
-        }
-    }
     
-    private var mainContent: some View {
+    var body: some View {
         ScrollView(.vertical) {
             HStack(alignment: .top) {
                 VStack {
@@ -55,6 +46,7 @@ struct InfoPane: View {
                 
             }
         }
+        .contentPadding(10)
     }
     
     @ViewBuilder

--- a/Xcodes/Frontend/View+ContentPadding.swift
+++ b/Xcodes/Frontend/View+ContentPadding.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    /// Adds an equal padding amount to specific edges of this view without clipping scrollable views.
+    /// - parameters:
+    ///     - edges: Edges to add paddings
+    ///     - length: The amount of padding to be added to edges.
+    /// - Returns: A view that’s padded by the specified amount on specified edges.
+    ///
+    /// This modifier uses safe area as paddings, making both non-scrollable and scrollable content looks great in any context.
+    public func contentPadding(_ edges: Edge.Set = .all, _ length: CGFloat? = nil) -> some View {
+        if #available(macOS 14.0, *) {
+            safeAreaPadding(edges, length)
+        } else {
+            safeAreaInset(edge: .top) {
+                EmptyView().frame(width: 0, height: 0)
+                    .padding(.top, edges.contains(.top) ? length : 0)
+            }
+            .safeAreaInset(edge: .bottom) {
+                EmptyView().frame(width: 0, height: 0)
+                    .padding(.bottom, edges.contains(.bottom) ? length : 0)
+            }
+            .safeAreaInset(edge: .leading) {
+                EmptyView().frame(width: 0, height: 0)
+                    .padding(.leading, edges.contains(.leading) ? length : 0)
+            }
+            .safeAreaInset(edge: .trailing) {
+                EmptyView().frame(width: 0, height: 0)
+                    .padding(.trailing, edges.contains(.trailing) ? length : 0)
+            }
+        }
+    }
+    
+    /// Adds an equal padding amount to all edges of this view without clipping scrollable views.
+    /// - parameters:
+    ///     - length: The amount of padding to be added to edges.
+    /// - Returns: A view that’s padded by the specified amount on all edges.
+    ///
+    /// This modifier uses safe area as paddings, making both non-scrollable and scrollable content looks great in any context.
+    public func contentPadding(_ length: CGFloat) -> some View {
+        contentPadding(.all, length)
+    }
+}


### PR DESCRIPTION
Previous PR that has been closed without merging: #539 

Based on #540, older OS still using padding around ScrollView which results in a hard clip. Technically, it's possible to add margins inside ScrollView, so, of course, older OS deserves that margin🤣. 

The code here uses safe area to add margins which might be the same with the new margin API, but supports older OS.