### PR TITLE
Set explicit SwiftPolyglot tag and update clone path

### DIFF
--- a/.github/workflows/xcstrings.yml
+++ b/.github/workflows/xcstrings.yml
@@ -14,9 +14,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Clone SwiftPolyglot
-      run: git clone https://github.com/appdecostudio/SwiftPolyglot.git
+      run: git clone https://github.com/appdecostudio/SwiftPolyglot.git --branch 0.3.1 ../SwiftPolyglot
       
     - name: validate translations
       run: |
-        swift build --package-path ./SwiftPolyglot --configuration release
-        swift run --package-path ./SwiftPolyglot swiftpolyglot "ca,de,el,es,fi,fr,hi,it,ja,ko,nl,pl,pt-BR,ru,tr,uk,zh-Hans,zh-Hant" --errorOnMissing
+        swift build --package-path ../SwiftPolyglot --configuration release
+        swift run --package-path ../SwiftPolyglot swiftpolyglot "ca,de,el,es,fi,fr,hi,it,ja,ko,nl,pl,pt-BR,ru,tr,uk,zh-Hans,zh-Hant" --errorOnMissing


### PR DESCRIPTION
I noticed there wasn't an explicit tag for `SwiftPolyglot`. I wanted to make sure your PRs are not affected by any potential breaking changes in the future, so setting the tag will prevent any issues before you get the chance to upgrade.