### PR TITLE
Left Align Unarchiving Pane

### DIFF
--- a/Xcodes/Frontend/InfoPane/InfoPane.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPane.swift
@@ -75,6 +75,7 @@ struct InfoPane: View {
 #Preview(XcodePreviewName.allCases[2].rawValue) { makePreviewContent(for: 2) }
 #Preview(XcodePreviewName.allCases[3].rawValue) { makePreviewContent(for: 3) }
 #Preview(XcodePreviewName.allCases[4].rawValue) { makePreviewContent(for: 4) }
+#Preview(XcodePreviewName.allCases[5].rawValue) { makePreviewContent(for: 5) }
 
 private func makePreviewContent(for index: Int) -> some View {
     let name = XcodePreviewName.allCases[index]
@@ -82,7 +83,7 @@ private func makePreviewContent(for index: Int) -> some View {
         .environmentObject(configure(AppState()) {
             $0.allXcodes = [xcodeDict[name]!]
         })
-        .frame(width: 300, height: 400)
+        .frame(width: 600, height: 400)
         .padding()
 }
 
@@ -92,6 +93,7 @@ enum XcodePreviewName: String, CaseIterable, Identifiable {
     case Populated_Uninstalled
     case Basic_Installed
     case Basic_Installing
+    case Basic_Unarchiving
     
     var id: XcodePreviewName { self }
 }
@@ -147,6 +149,14 @@ var xcodeDict: [XcodePreviewName: Xcode] = [
                 $0.throughput = 9_211_681
             }
         )),
+        selected: false,
+        icon: nil,
+        sdks: nil,
+        compilers: nil
+    ),
+    .Basic_Unarchiving: .init(
+        version: _versionWithMeta,
+        installState: .installing(.unarchiving),
         selected: false,
         icon: nil,
         sdks: nil,

--- a/Xcodes/Frontend/InfoPane/InfoPaneControls.swift
+++ b/Xcodes/Frontend/InfoPane/InfoPaneControls.swift
@@ -25,6 +25,7 @@ struct InfoPaneControls: View {
             case .installing(let installationStep):
                 HStack(alignment: .top) {
                     InstallationStepDetailView(installationStep: installationStep)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     CancelInstallButton(xcode: xcode)
                 }
             case .installed(_):
@@ -39,6 +40,7 @@ struct InfoPaneControls: View {
 #Preview(XcodePreviewName.allCases[2].rawValue) { makePreviewContent(for: 2) }
 #Preview(XcodePreviewName.allCases[3].rawValue) { makePreviewContent(for: 3) }
 #Preview(XcodePreviewName.allCases[4].rawValue) { makePreviewContent(for: 4) }
+#Preview(XcodePreviewName.allCases[5].rawValue) { makePreviewContent(for: 5) }
 
 private func makePreviewContent(for index: Int) -> some View {
   let name = XcodePreviewName.allCases[index]
@@ -47,6 +49,6 @@ private func makePreviewContent(for index: Int) -> some View {
     .environmentObject(configure(AppState()) {
       $0.allXcodes = [xcodeDict[name]!]
     })
-    .frame(width: 300)
+    .frame(width: 500)
     .padding()
 }


### PR DESCRIPTION
- Achieves left aligning the "Unarchiving" pane for a nicer look, or any step, as well as making the close button appear in the same spot as a side effect.
- Make some previews wider for better previewing

| Prior Step (reference)  | Before | After |
| ------------- | ------------- | ------------- |
| <img width="391" alt="Screenshot 2024-05-28 at 11 45 49 AM" src="https://github.com/XcodesOrg/XcodesApp/assets/20747774/eeffd321-a243-4ec7-94f8-9d6b32632488">  | <img width="395" alt="Screenshot 2024-05-28 at 11 45 39 AM" src="https://github.com/XcodesOrg/XcodesApp/assets/20747774/314b1725-0a5a-408d-8857-a553aa8fbf40"> | <img width="403" alt="Screenshot 2024-05-28 at 11 45 20 AM" src="https://github.com/XcodesOrg/XcodesApp/assets/20747774/a258c490-6692-4c9a-b604-c613fd901e12"> |
