### PR TITLE
Disallow changes to managed preferences

### DIFF
--- a/Xcodes/Backend/AppState+Install.swift
+++ b/Xcodes/Backend/AppState+Install.swift
@@ -13,8 +13,8 @@ extension AppState {
     
     // check to see if we should auto install for the user
     public func autoInstallIfNeeded() {
-        guard let storageValue = UserDefaults.standard.object(forKey: "autoInstallation") as? Int, let autoInstallType = AutoInstallationType(rawValue: storageValue) else { return }
-        
+        guard let storageValue = Current.defaults.get(forKey: "autoInstallation") as? Int, let autoInstallType = AutoInstallationType(rawValue: storageValue) else { return }
+
         if autoInstallType == .none { return }
         
         // get newest xcode version

--- a/Xcodes/Backend/AppState+Runtimes.swift
+++ b/Xcodes/Backend/AppState+Runtimes.swift
@@ -90,7 +90,7 @@ extension AppState {
         // sets a proper cookie for runtimes
         try await validateADCSession(path: runtime.downloadPath)
         
-        let downloader = Downloader(rawValue: UserDefaults.standard.string(forKey: "downloader") ?? "aria2") ?? .aria2
+        let downloader = Downloader(rawValue: Current.defaults.string(forKey: "downloader") ?? "aria2") ?? .aria2
         
         let url = URL(string: runtime.source)!
         let expectedRuntimePath = Path.xcodesApplicationSupport/"\(url.lastPathComponent)"

--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -10,6 +10,23 @@ import os.log
 import DockProgress
 import XcodesKit
 
+enum PreferenceKey: String {
+    case installPath
+    case localPath
+    case unxipExperiment
+    case createSymLinkOnSelect
+    case onSelectActionType
+    case showOpenInRosettaOption
+    case autoInstallation
+    case SUEnableAutomaticChecks
+    case includePrereleaseVersions
+    case downloader
+    case dataSource
+    case xcodeListCategory
+
+    func isManaged() -> Bool { UserDefaults.standard.objectIsForced(forKey: self.rawValue) }
+}
+
 class AppState: ObservableObject {
     private let client = AppleAPI.Client()
     internal let runtimeService = RuntimeService()
@@ -66,18 +83,24 @@ class AppState: ObservableObject {
         }
     }
     
+    var disableLocalPathChange: Bool { PreferenceKey.localPath.isManaged() }
+
     @Published var installPath = "" {
         didSet {
             Current.defaults.set(installPath, forKey: "installPath")
         }
     }
-    
+
+    var disableInstallPathChange: Bool { PreferenceKey.installPath.isManaged() }
+
     @Published var unxipExperiment = false {
         didSet {
             Current.defaults.set(unxipExperiment, forKey: "unxipExperiment")
         }
     }
     
+    var disableUnxipExperiment: Bool { PreferenceKey.unxipExperiment.isManaged() }
+
     @Published var createSymLinkOnSelect = false {
         didSet {
             Current.defaults.set(createSymLinkOnSelect, forKey: "createSymLinkOnSelect")
@@ -85,7 +108,7 @@ class AppState: ObservableObject {
     }
     
     var createSymLinkOnSelectDisabled: Bool {
-        return onSelectActionType == .rename
+        return onSelectActionType == .rename || PreferenceKey.createSymLinkOnSelect.isManaged()
     }
     
     @Published var onSelectActionType = SelectedActionType.none {
@@ -98,6 +121,8 @@ class AppState: ObservableObject {
         }
     }
     
+    var onSelectActionTypeDisabled: Bool { PreferenceKey.onSelectActionType.isManaged() }
+
     @Published var showOpenInRosettaOption = false {
         didSet {
             Current.defaults.set(showOpenInRosettaOption, forKey: "showOpenInRosettaOption")
@@ -178,8 +203,8 @@ class AppState: ObservableObject {
     // MARK: Timer
     /// Runs a timer every 6 hours when app is open to check if it needs to auto install any xcodes
     func setupAutoInstallTimer() {
-        guard let storageValue = UserDefaults.standard.object(forKey: "autoInstallation") as? Int, let autoInstallType = AutoInstallationType(rawValue: storageValue) else { return }
-        
+        guard let storageValue = Current.defaults.get(forKey: "autoInstallation") as? Int, let autoInstallType = AutoInstallationType(rawValue: storageValue) else { return }
+
         if autoInstallType == .none { return }
         
         autoInstallTimer = Timer.scheduledTimer(withTimeInterval: 60*60*6, repeats: true) { [weak self] _ in
@@ -479,7 +504,7 @@ class AppState: ObservableObject {
                     .mapError { $0 as Error }
             }
             .flatMap { [unowned self] in
-                self.install(.version(availableXcode), downloader: Downloader(rawValue: UserDefaults.standard.string(forKey: "downloader") ?? "aria2") ?? .aria2)
+                self.install(.version(availableXcode), downloader: Downloader(rawValue: Current.defaults.string(forKey: "downloader") ?? "aria2") ?? .aria2)
             }
             .receive(on: DispatchQueue.main)
             .sink(
@@ -505,7 +530,7 @@ class AppState: ObservableObject {
     func installWithoutLogin(id: Xcode.ID) {
         guard let availableXcode = availableXcodes.first(where: { $0.version == id }) else { return }
         
-        installationPublishers[id] = self.install(.version(availableXcode), downloader: Downloader(rawValue: UserDefaults.standard.string(forKey: "downloader") ?? "aria2") ?? .aria2)
+        installationPublishers[id] = self.install(.version(availableXcode), downloader: Downloader(rawValue: Current.defaults.string(forKey: "downloader") ?? "aria2") ?? .aria2)
             .receive(on: DispatchQueue.main)
             .sink(
                 receiveCompletion: { [unowned self] completion in

--- a/Xcodes/Backend/DataSource.swift
+++ b/Xcodes/Backend/DataSource.swift
@@ -14,4 +14,6 @@ public enum DataSource: String, CaseIterable, Identifiable, CustomStringConverti
         case .xcodeReleases: return "Xcode Releases"
         }
     }
+
+    var isManaged: Bool { PreferenceKey.dataSource.isManaged() }
 }

--- a/Xcodes/Backend/Downloader.swift
+++ b/Xcodes/Backend/Downloader.swift
@@ -13,4 +13,6 @@ public enum Downloader: String, CaseIterable, Identifiable, CustomStringConverti
         case .aria2: return "aria2"
         }
     }
+
+    var isManaged: Bool { PreferenceKey.downloader.isManaged() }
 }

--- a/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/AdvancedPreferencePane.swift
@@ -36,6 +36,7 @@ struct AdvancedPreferencePane: View {
                             self.appState.installPath = path.string
                         }
                     }
+                    .disabled(appState.disableInstallPathChange)
                     Text("InstallPathDescription")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -72,6 +73,7 @@ struct AdvancedPreferencePane: View {
                             self.appState.localPath = path.string
                         }
                     }
+                    .disabled(appState.disableLocalPathChange)
                     Text("LocalCachePathDescription")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -93,7 +95,8 @@ struct AdvancedPreferencePane: View {
                     }
                     .labelsHidden()
                     .pickerStyle(.inline)
-                    
+                    .disabled(appState.onSelectActionTypeDisabled)
+
                     Text(appState.onSelectActionType.detailedDescription)
                         .font(.footnote)
                         .foregroundStyle(.secondary)

--- a/Xcodes/Frontend/Preferences/DownloadPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/DownloadPreferencePane.swift
@@ -19,7 +19,7 @@ struct DownloadPreferencePane: View {
                     }
                     .labelsHidden()
                     .fixedSize()
-                    
+
                     Text("DataSourceDescription")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -27,7 +27,8 @@ struct DownloadPreferencePane: View {
                 }
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
-            
+            .disabled(dataSource.isManaged)
+
             GroupBox(label: Text("Downloader")) {
                 VStack(alignment: .leading) {
                     Picker("Downloader", selection: $downloader) {
@@ -38,7 +39,7 @@ struct DownloadPreferencePane: View {
                     }
                     .labelsHidden()
                     .fixedSize()
-                    
+
                     Text("DownloaderDescription")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -46,6 +47,7 @@ struct DownloadPreferencePane: View {
                 }
             }
             .groupBoxStyle(PreferencesGroupBoxStyle())
+            .disabled(downloader.isManaged)
         }
     }
 }

--- a/Xcodes/Frontend/Preferences/ExperiementsPreferencePane.swift
+++ b/Xcodes/Frontend/Preferences/ExperiementsPreferencePane.swift
@@ -13,6 +13,7 @@ struct ExperimentsPreferencePane: View {
                         "UseUnxipExperiment",
                         isOn: $appState.unxipExperiment
                     )
+                    .disabled(appState.disableUnxipExperiment)
                     Text("FasterUnxipDescription")
                         .font(.footnote)
                         .foregroundStyle(.secondary)

--- a/Xcodes/Frontend/XcodeList/MainToolbar.swift
+++ b/Xcodes/Frontend/XcodeList/MainToolbar.swift
@@ -44,6 +44,7 @@ struct MainToolbarModifier: ViewModifier {
                 }
             }
             .help("FilterAvailableDescription")
+            .disabled(category.isManaged)
 
             Button(action: {
                 isInstalledOnly.toggle()

--- a/Xcodes/Frontend/XcodeList/XcodeListCategory.swift
+++ b/Xcodes/Frontend/XcodeList/XcodeListCategory.swift
@@ -14,4 +14,6 @@ enum XcodeListCategory: String, CaseIterable, Identifiable, CustomStringConverti
             case .beta: return localizeString("Beta")
         }
     }
+
+    var isManaged: Bool { PreferenceKey.xcodeListCategory.isManaged() }
 }


### PR DESCRIPTION
- Define enumerations for preferences that can be managed in an enterprise environment using MDM
- Add methods in AppState to check for managed preferences
- Update Advanced, Download, Experiments and Update preference pane to disable controls to modify any of the managed preferences