### PR TITLE
fix: Update GitHub URLs in help menu

### DIFF
--- a/Xcodes/XcodesApp.swift
+++ b/Xcodes/XcodesApp.swift
@@ -51,19 +51,19 @@ struct XcodesApp: App {
 
             CommandGroup(replacing: CommandGroupPlacement.help) {
                 Button("Menu.GitHubRepo") {
-                    let xcodesRepoURL = URL(string: "https://github.com/RobotsAndPencils/XcodesApp/")!
+                    let xcodesRepoURL = URL(string: "https://github.com/XcodesOrg/XcodesApp/")!
                     openURL(xcodesRepoURL)
                 }
 
                 Divider()
 
                 Button("Menu.ReportABug") {
-                    let bugReportURL = URL(string: "https://github.com/RobotsAndPencils/XcodesApp/issues/new?assignees=&labels=bug&template=bug_report.md&title=")!
+                    let bugReportURL = URL(string: "https://github.com/XcodesOrg/XcodesApp/issues/new?assignees=&labels=bug&template=bug_report.md&title=")!
                     openURL(bugReportURL)
                 }
 
                 Button("Menu.RequestNewFeature") {
-                    let featureRequestURL = URL(string: "https://github.com/RobotsAndPencils/XcodesApp/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=")!
+                    let featureRequestURL = URL(string: "https://github.com/XcodesOrg/XcodesApp/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=")!
                     openURL(featureRequestURL)
                 }
             }


### PR DESCRIPTION
Tiny fix in help menu to use updated GitHub URLs. Changed "https://github.com/RobotsAndPencils/XcodesApp" to "https://github.com/XcodesOrg/XcodesApp"

Will solve issue #580 