### PR TITLE
Fix runtime downloading

### DIFF
--- a/Xcodes/XcodesKit/Sources/XcodesKit/Models/Runtimes/Runtimes.swift
+++ b/Xcodes/XcodesKit/Sources/XcodesKit/Models/Runtimes/Runtimes.swift
@@ -11,7 +11,7 @@ public struct DownloadableRuntimesResponse: Codable {
 public struct DownloadableRuntime: Codable, Identifiable, Hashable {
     public let category: Category
     public let simulatorVersion: SimulatorVersion
-    public let source: String
+    public let source: String?
     public let dictionaryVersion: Int
     public let contentType: ContentType
     public let platform: Platform
@@ -21,11 +21,14 @@ public struct DownloadableRuntime: Codable, Identifiable, Hashable {
     public let hostRequirements: HostRequirements?
     public let name: String
     public let authentication: Authentication?
-    public var url: URL {
-        return URL(string: source)!
+    public var url: URL? {
+        if let source {
+            return URL(string: source)!
+        }
+        return nil
     }
-    public var downloadPath: String {
-        url.path
+    public var downloadPath: String? {
+        url?.path
     }
     
     // dynamically updated - not decoded
@@ -117,6 +120,7 @@ extension DownloadableRuntime {
     public enum ContentType: String, Codable {
         case diskImage = "diskImage"
         case package = "package"
+        case cryptexDiskImage = "cryptexDiskImage"
     }
 
     public enum Platform: String, Codable {

--- a/Xcodes/XcodesKit/Sources/XcodesKit/Services/RuntimeService.swift
+++ b/Xcodes/XcodesKit/Sources/XcodesKit/Services/RuntimeService.swift
@@ -22,9 +22,14 @@ public struct RuntimeService {
         
         // Apple gives a plist for download
         let (data, _) = try await networkService.requestData(urlRequest, validators: [])
-        let decodedResponse = try PropertyListDecoder().decode(DownloadableRuntimesResponse.self, from: data)
-
-        return decodedResponse
+        do {
+            let decodedResponse = try PropertyListDecoder().decode(DownloadableRuntimesResponse.self, from: data)
+            return decodedResponse
+        } catch {
+            print("error: \(error)")
+            throw error
+        }
+        
     }
     
     public func installedRuntimes() async throws -> [InstalledRuntime] {


### PR DESCRIPTION
Supports newer plist from Apple where CryptexDiskImage for iOS 18 runtimes are new and don't include a source url
Give better error messages when downloading iOS 18
