### PR TITLE
[Issue-578] - adjust AuthOptionsResponse parser decode

### DIFF
--- a/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
@@ -331,15 +331,15 @@ public enum TwoFactorOption: Equatable {
 public struct AuthOptionsResponse: Equatable, Decodable {
     public let trustedPhoneNumbers: [TrustedPhoneNumber]?
     public let trustedDevices: [TrustedDevice]?
-    public let securityCode: SecurityCodeInfo
+    public let securityCode: SecurityCodeInfo?
     public let noTrustedDevices: Bool?
     public let serviceErrors: [ServiceError]?
     
     public init(
         trustedPhoneNumbers: [AuthOptionsResponse.TrustedPhoneNumber]?, 
         trustedDevices: [AuthOptionsResponse.TrustedDevice]?, 
-        securityCode: AuthOptionsResponse.SecurityCodeInfo, 
-        noTrustedDevices: Bool? = nil, 
+        securityCode: AuthOptionsResponse.SecurityCodeInfo? = nil,
+        noTrustedDevices: Bool? = nil,
         serviceErrors: [ServiceError]? = nil
     ) {
         self.trustedPhoneNumbers = trustedPhoneNumbers

--- a/Xcodes/Frontend/SignIn/SignIn2FAView.swift
+++ b/Xcodes/Frontend/SignIn/SignIn2FAView.swift
@@ -10,12 +10,12 @@ struct SignIn2FAView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text(String(format: localizeString("DigitCodeDescription"), authOptions.securityCode.length))
+            Text(String(format: localizeString("DigitCodeDescription"), authOptions.securityCode?.length ?? ""))
                 .fixedSize(horizontal: true, vertical: false)
             
             HStack {
                 Spacer()
-                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode.length) {
+                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode?.length ?? 0) {
                     appState.submitSecurityCode(.device(code: $0), sessionData: sessionData)
                 }
                 Spacer()
@@ -32,7 +32,7 @@ struct SignIn2FAView: View {
                     Text("Continue")
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(code.count != authOptions.securityCode.length)
+                .disabled(code.count != authOptions.securityCode?.length)
             }
             .frame(height: 25)
         }

--- a/Xcodes/Frontend/SignIn/SignInPhoneListView.swift
+++ b/Xcodes/Frontend/SignIn/SignInPhoneListView.swift
@@ -11,7 +11,7 @@ struct SignInPhoneListView: View {
     var body: some View {
         VStack(alignment: .leading) {
             if let phoneNumbers = authOptions.trustedPhoneNumbers, !phoneNumbers.isEmpty {
-                Text(String(format: localizeString("SelectTrustedPhone"), authOptions.securityCode.length))
+                Text(String(format: localizeString("SelectTrustedPhone"), authOptions.securityCode?.length ?? ""))
 
                 List(phoneNumbers, selection: $selectedPhoneNumberID) {
                     Text($0.numberWithDialCode)

--- a/Xcodes/Frontend/SignIn/SignInSMSView.swift
+++ b/Xcodes/Frontend/SignIn/SignInSMSView.swift
@@ -11,11 +11,11 @@ struct SignInSMSView: View {
 
     var body: some View {
         VStack(alignment: .leading) {
-            Text(String(format: localizeString("EnterDigitCodeDescription"), authOptions.securityCode.length, trustedPhoneNumber.numberWithDialCode))
+            Text(String(format: localizeString("EnterDigitCodeDescription"), authOptions.securityCode?.length ?? "", trustedPhoneNumber.numberWithDialCode))
             
             HStack {
                 Spacer()
-                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode.length) {
+                PinCodeTextField(code: $code, numberOfDigits: authOptions.securityCode?.length ?? 0) {
                     appState.submitSecurityCode(.sms(code: $0, phoneNumberId: trustedPhoneNumber.id), sessionData: sessionData)
                 }
                 Spacer()
@@ -31,7 +31,7 @@ struct SignInSMSView: View {
                     Text("Continue")
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(code.count != authOptions.securityCode.length)
+                .disabled(code.count != authOptions.securityCode?.length)
             }
             .frame(height: 25)
         }

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -1547,7 +1547,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Are you sure you want to stop the installation of Xcode %@?"
+            "value" : "Tem certeza que deseja interromper a instalação do Xcode %@?"
           }
         },
         "ru" : {
@@ -1798,7 +1798,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Delete"
+            "value" : "Remover"
           }
         },
         "ru" : {
@@ -2299,7 +2299,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Xcode %@ requere macOS %@, mas você está rodando macOS %@, você ainda quer instalá-lo?"
+            "value" : "Xcode %@ requer macOS %@, mas você está rodando macOS %@, você ainda quer instalá-lo?"
           }
         },
         "ru" : {
@@ -3426,7 +3426,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Could not find file \"%@\"."
+            "value" : "Não foi possível encontrar o arquivo \"%@\"."
           }
         },
         "ru" : {
@@ -6609,7 +6609,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Create Symlink as Xcode-Beta.app"
+            "value" : "Criar Symlink como Xcode-Beta.app"
           }
         },
         "ru" : {
@@ -8220,7 +8220,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Error"
+            "value" : "Erro"
           }
         },
         "ru" : {
@@ -8339,7 +8339,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Experiments"
+            "value" : "Experimentos"
           }
         },
         "ru" : {
@@ -12693,7 +12693,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Install Directory"
+            "value" : "Diretório de Instalação"
           }
         },
         "ru" : {
@@ -12941,7 +12941,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Xcodes searches and installs to a single directory. By default (and recommended) is to keep this /Applications. Any changes to where Xcode is stored may result in other apps/services to stop working. "
+            "value" : "O Xcodes pesquisa e instala em um único diretório. Por padrão (e recomendado) é manter este /Applications. Quaisquer alterações no local onde o Xcode está armazenado podem fazer com que outros aplicativos/serviços parem de funcionar."
           }
         },
         "ru" : {
@@ -16523,7 +16523,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "On select, will keep the name as the version eg. Xcode-13.4.1.app"
+            "value" : "Ao selecionar, manterá o nome conforme a versão, por exemplo. Xcode-13.4.1.app"
           }
         },
         "ru" : {
@@ -17009,7 +17009,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Open In Rosetta"
+            "value" : "Abrir com Rosetta"
           }
         },
         "ru" : {
@@ -17375,7 +17375,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perform post-install steps"
+            "value" : "Execute as etapas pós-instalação"
           }
         },
         "ru" : {
@@ -17493,7 +17493,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Platforms"
+            "value" : "Plataformas"
           }
         },
         "ru" : {
@@ -17617,7 +17617,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Installed Platforms"
+            "value" : "Plataformas Instaladas"
           }
         },
         "ru" : {
@@ -17742,7 +17742,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Below are a list of platforms that are installed on this machine. "
+            "value" : "Abaixo está uma lista de plataformas instaladas nesta máquina."
           }
         },
         "ru" : {
@@ -18599,7 +18599,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Release"
+            "value" : "Lançamento"
           }
         },
         "ru" : {
@@ -18971,7 +18971,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Somente release"
+            "value" : "Somente lançamento"
           }
         },
         "ru" : {
@@ -20686,7 +20686,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Support Xcodes"
+            "value" : "Apoie Xcodes"
           }
         },
         "ru" : {
@@ -21547,7 +21547,7 @@
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Quando performar unxipping, use experiment"
+            "value" : "Quando executar unxipping, use experimentos"
           }
         },
         "ru" : {


### PR DESCRIPTION
When the user has a 2FA with security keys (yubikey), the AuthOptionsResponse cannot be parsed because `securityCode` attribute is not optional and the `AuthenticationError.accountUsesUnknownAuthenticationKind` is never shown.

The correct authType for security keys is not implemented and needs to check more the documentation for this.

PS: also, I have updated some missing pt-br localization strings @MattKiazyk


Before:
![Screenshot 2024-07-04 at 00 02 09](https://private-user-images.githubusercontent.com/138769908/339219712-49f8d114-c5de-4627-a823-81b254f4036b.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjAwNjQyMzAsIm5iZiI6MTcyMDA2MzkzMCwicGF0aCI6Ii8xMzg3Njk5MDgvMzM5MjE5NzEyLTQ5ZjhkMTE0LWM1ZGUtNDYyNy1hODIzLTgxYjI1NGY0MDM2Yi5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwNzA0JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDcwNFQwMzMyMTBaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0yYTY1Y2U2OTQxNDI4OTA1YWM2NjE0YTY2MDdjZjM1Yzk0MWZiOGU4OTljM2YxZjI1MTIyYWZlNGE1MGJmMjM2JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.ENQRdcKZ1cpIFEFPkqlhRYiuvsUcvdQp3sbmJVaMoc0)

After
![Screenshot 2024-07-04 at 00 02 09](https://github.com/XcodesOrg/XcodesApp/assets/788332/6cb566dc-77b0-4ded-8e58-7bcfdf19c359)
