### PR TITLE
Update label for Cancel Install Button

### DIFF
--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -61,7 +61,7 @@ struct CancelInstallButton: View {
     
     var body: some View {
         Button(action: cancelInstall) {
-            Image(systemName: "xmark.circle.fill")
+            Label("Cancel", systemImage: "xmark")
         }
         .help(localizeString("StopInstallation"))
         .buttonStyle(.plain)


### PR DESCRIPTION
## Before 
<img width="1230" alt="截屏2024-08-17 11 20 01" src="https://github.com/user-attachments/assets/2c18a679-bab5-48b6-a5ec-27270d70c854">

## After 
<img width="1230" alt="截屏2024-08-17 11 34 26" src="https://github.com/user-attachments/assets/af19a231-da80-438a-94bb-7af241502854">

This gives more clarity to the button intent and better matches other types of context menus.