### PR TITLE
Fix one Greek localization. Add one zh_Hans localization.

### DIFF
--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -8029,7 +8029,7 @@
         "el" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Εισάγετε τον %2$d-ψήφιο κωδικού που εστάλη στο %2$@:"
+            "value" : "Εισάγετε τον %1$d-ψήφιο κωδικού που εστάλη στο %2$@:"
           }
         },
         "en" : {
@@ -17641,7 +17641,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Installed Platforms"
+            "value" : "已安装的平台"
           }
         },
         "zh-Hant" : {


### PR DESCRIPTION
Add zh_Hans translation for "Installed Platforms".

Fix Greek translation for "Enter the %1$d digit code sent to %2$@". 
The wrong translation has "%1$d" written as "%2$d". This causes the compilation to fail using Xcode 16.