### PR TITLE
Add `authenticating` to the `XcodeInstallationStep`

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -436,6 +436,11 @@ class AppState: ObservableObject {
         guard let availableXcode = availableXcodes.first(where: { $0.version == id }) else { return }
 
         installationPublishers[id] = signInIfNeeded()
+            .handleEvents(
+                receiveSubscription: { [unowned self] _ in
+                    self.setInstallationStep(of: availableXcode.version, to: .authenticating)
+                }
+            )
             .flatMap { [unowned self] in
                 // signInIfNeeded might finish before the user actually authenticates if UI is involved. 
                 // This publisher will wait for the @Published authentication state to change to authenticated or unauthenticated before finishing,

--- a/Xcodes/Backend/XcodeCommands.swift
+++ b/Xcodes/Backend/XcodeCommands.swift
@@ -35,12 +35,11 @@ struct XcodeCommands: Commands {
 
 struct InstallButton: View {
     @EnvironmentObject var appState: AppState
-    @State private var isLoading = false
 
     let xcode: Xcode?
 
     var body: some View {
-        ProgressButton(isInProgress: isLoading) {
+        Button {
             install()
         } label: {
             Text("Install")
@@ -49,7 +48,6 @@ struct InstallButton: View {
     }
 
     private func install() {
-        isLoading = true
         guard let xcode = xcode else { return }
         appState.checkMinVersionAndInstall(id: xcode.id)
     }

--- a/Xcodes/Frontend/InfoPane/InstallationStepDetailView.swift
+++ b/Xcodes/Frontend/InfoPane/InstallationStepDetailView.swift
@@ -17,7 +17,7 @@ struct InstallationStepDetailView: View {
                         showsAdditionalDescription: true
                     )
 
-                case .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
+                case .authenticating, .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
                     ProgressView()
                         .scaleEffect(0.5)
             }

--- a/Xcodes/Frontend/XcodeList/InstallationStepRowView.swift
+++ b/Xcodes/Frontend/XcodeList/InstallationStepRowView.swift
@@ -18,7 +18,7 @@ struct InstallationStepRowView: View {
                     controlSize: .small,
                     style: .spinning
                 )
-            case .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
+            case .authenticating, .unarchiving, .moving, .trashingArchive, .checkingSecurity, .finishing:
                 ProgressView()
                     .scaleEffect(0.5)
             }

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -4446,6 +4446,23 @@
         }
       }
     },
+    "Authenticating" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認証中"
+          }
+        }
+      }
+    },
     "AutomaticallyCreateSymbolicLink" : {
       "localizations" : {
         "ar" : {

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -4449,7 +4449,61 @@
     "Authenticating" : {
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "ca" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Authenticating"
@@ -4459,6 +4513,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "認証中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticating"
           }
         }
       }

--- a/Xcodes/XcodesKit/Sources/XcodesKit/Models/XcodeInstallationStep.swift
+++ b/Xcodes/XcodesKit/Sources/XcodesKit/Models/XcodeInstallationStep.swift
@@ -9,6 +9,7 @@ import Foundation
 
 // A numbered step
 public enum XcodeInstallationStep: Equatable, CustomStringConvertible {
+    case authenticating
     case downloading(progress: Progress)
     case unarchiving
     case moving(destination: String)
@@ -22,6 +23,8 @@ public enum XcodeInstallationStep: Equatable, CustomStringConvertible {
 
     public var message: String {
         switch self {
+        case .authenticating:
+            return localizeString("Authenticating")
         case .downloading:
             return localizeString("Downloading")
         case .unarchiving:
@@ -39,16 +42,17 @@ public enum XcodeInstallationStep: Equatable, CustomStringConvertible {
 
     public var stepNumber: Int {
         switch self {
-        case .downloading:      return 1
-        case .unarchiving:      return 2
-        case .moving:           return 3
-        case .trashingArchive:  return 4
-        case .checkingSecurity: return 5
-        case .finishing:        return 6
+        case .authenticating:   return 1
+        case .downloading:      return 2
+        case .unarchiving:      return 3
+        case .moving:           return 4
+        case .trashingArchive:  return 5
+        case .checkingSecurity: return 6
+        case .finishing:        return 7
         }
     }
 
-    public var stepCount: Int { 6 }
+    public var stepCount: Int { 7 }
 }
 
 func localizeString(_ key: String, comment: String = "") -> String {


### PR DESCRIPTION
Fixes #551 

Thanks for creating this awesome app!

This PR aims to fix a minor issue where it keeps displaying the indicator on the install button on error.
To fix it, this PR introduces `authenticating` state to the `XcodeInstallationStep` and makes it to the `installing` state once "INSTALL" button is clicked.

## Screen Capture

### Before

https://github.com/user-attachments/assets/12efaa2d-51ef-42ff-8fb4-5d0035f61c14

### After

https://github.com/user-attachments/assets/ad397f66-0f9b-43ca-bc82-c36e9c6b2b4d



