### PR TITLE
feat: support downloading of cryptex (ex iOS 18+) runtimes

### DIFF
--- a/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ObservingProgressIndicator.swift
@@ -31,6 +31,7 @@ public struct ObservingProgressIndicator: View {
             self.progress = progress
             cancellable = progress.publisher(for: \.fractionCompleted)
                 .combineLatest(progress.publisher(for: \.localizedAdditionalDescription))
+                .combineLatest(progress.publisher(for: \.isIndeterminate))
                 .throttle(for: 1.0, scheduler: DispatchQueue.main, latest: true)
                 .sink { [weak self] _ in self?.objectWillChange.send() }
         }
@@ -77,6 +78,18 @@ struct ObservingProgressBar_Previews: PreviewProvider {
                     $0.totalUnitCount = 11944848484
                     $0.completedUnitCount = 848444920
                     $0.throughput = 9211681
+                },
+                controlSize: .regular,
+                style: .bar,
+                showsAdditionalDescription: true
+            )
+            
+            ObservingProgressIndicator(
+                configure(Progress()) {
+                    $0.kind = .file
+                    $0.fileOperationKind = .downloading
+                    $0.totalUnitCount = 0
+                    $0.completedUnitCount = 0
                 },
                 controlSize: .regular,
                 style: .bar,

--- a/Xcodes/Frontend/Common/ProgressIndicator.swift
+++ b/Xcodes/Frontend/Common/ProgressIndicator.swift
@@ -22,7 +22,10 @@ struct ProgressIndicator: NSViewRepresentable {
         nsView.doubleValue = doubleValue
         nsView.controlSize = controlSize
         nsView.isIndeterminate = isIndeterminate
+        nsView.usesThreadedAnimation = true
+        
         nsView.style = style
+        nsView.startAnimation(nil)
     }
 }
 

--- a/Xcodes/Frontend/InfoPane/RuntimeInstallationStepDetailView.swift
+++ b/Xcodes/Frontend/InfoPane/RuntimeInstallationStepDetailView.swift
@@ -26,8 +26,12 @@ struct RuntimeInstallationStepDetailView: View {
                 )
                 
             case .installing, .trashingArchive:
-                ProgressView()
-                    .scaleEffect(0.5)
+                ObservingProgressIndicator(
+                    Progress(),
+                    controlSize: .regular,
+                    style: .bar,
+                    showsAdditionalDescription: false
+                )
             }
         }
     }


### PR DESCRIPTION
fixes #618 fixes #575 Fixes #571 

Since iOS 18, Apple has switched how runtimes are downloaded. They no longer fully support downloading direct from their website (at least automatically via their runtime source list), and instead use cryptex images. 

With Xcode 16.1 beta 3, `xcodebuild` [now supports downloading runtimes by individual versions](https://developer.apple.com/documentation/xcode-release-notes/xcode-16_1-release-notes#New-Features). Previously you could only download the current runtime for a selected Xcode, which for Xcodes isn't the point.

This PR hooks all that up by using the `xcodebuild -downloadPlatform iOS -buildVersion 22B5045f` type of command to download the runtime as well as install it. The obvious downside of using this way, is we no longer get to use `aria2` for faster downloads, but at least everything can now be done via Xcodes again.

Since `xcodebuild` now installs as well, updated the progress view to be `indeterminate` so it shows it doing something as it's installing. 

## Testing
- Please make Xcode 16.1 beta 3 your active Xcode
- Download a runtime to see if it works. 

