### PR TITLE
Add preference keys for 'Restrict allowed versions' & hide 'Support Xcodes'

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -24,6 +24,8 @@ enum PreferenceKey: String {
     case downloader
     case dataSource
     case xcodeListCategory
+    case allowedMajorVersions
+    case hideSupportXcodes
 
     func isManaged() -> Bool { UserDefaults.standard.objectIsForced(forKey: self.rawValue) }
 }

--- a/Xcodes/Frontend/XcodeList/BottomStatusBar.swift
+++ b/Xcodes/Frontend/XcodeList/BottomStatusBar.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 struct BottomStatusModifier: ViewModifier {
     @EnvironmentObject var appState: AppState
+    @AppStorage(PreferenceKey.hideSupportXcodes.rawValue) var hideSupportXcodes = false
+
     @SwiftUI.Environment(\.openURL) var openURL: OpenURLAction
     
     func body(content: Content) -> some View {
@@ -20,17 +22,19 @@ struct BottomStatusModifier: ViewModifier {
                 Divider()
                 HStack {
                     Text(appState.bottomStatusBarMessage)
-                        .font(.subheadline)
+                            .font(.subheadline)
                     Spacer()
-                    Button(action: {
-                        openURL(URL(string: "https://opencollective.com/xcodesapp")!)
-                    }) {
-                        HStack {
-                            Image(systemName: "heart.circle")
-                            Text("Support.Xcodes")
+                    if !hideSupportXcodes {
+                        Button(action: {
+                            openURL(URL(string: "https://opencollective.com/xcodesapp")!)
+                        }) {
+                            HStack {
+                                Image(systemName: "heart.circle")
+                                Text("Support.Xcodes")
+                            }
                         }
                     }
-                    Text(Bundle.main.shortVersion!)
+                    Text("\(Bundle.main.shortVersion!) (\(Bundle.main.version!))")
                         .font(.subheadline)
                 }
                 .frame(maxWidth: .infinity, maxHeight: 30, alignment: .leading)
@@ -51,8 +55,34 @@ extension View {
 
 struct Previews_BottomStatusBar_Previews: PreviewProvider {
     static var previews: some View {
-        HStack {
-        
-        }.bottomStatusBar()
+        Group {
+            HStack {
+
+            }
+            .bottomStatusBar()
+            .environmentObject({ () -> AppState in
+                let a = AppState()
+                return a }()
+            )
+            .defaultAppStorage({ () -> UserDefaults in
+                let d = UserDefaults(suiteName: "hide_support")!
+                d.set(true, forKey: PreferenceKey.hideSupportXcodes.rawValue)
+                return d
+            }())
+
+            HStack {
+
+            }
+            .bottomStatusBar()
+            .environmentObject({ () -> AppState in
+                let a = AppState()
+                return a }()
+            )
+            .defaultAppStorage({ () -> UserDefaults in
+                let d = UserDefaults(suiteName: "show_support")!
+                d.set(false, forKey: PreferenceKey.hideSupportXcodes.rawValue)
+                return d
+            }())
+        }
     }
 }


### PR DESCRIPTION
- Introduced a new preference keys allowedMajorVersions, hideSupportXcodes
- allowedMajorVersions defaults to Int.max (ie allow all versions till date)
- allowedMajorVersions is used to limit the number of major versions to as many as value set for this key. Eg: A value of 1 would allow the latest GA version and one major version before A value of 0 would allow only the latest GA version A value of 2 would allow the latest GA and previous two major versions
- allowedMajorVersions does not have preference UI $ defaults write com.xcodesorg.xcodesapp allowedMajorVersions 2 #to limit to current GA and previous major $ defaults delete com.xcodesorg.xcodesapp allowedMajorVersions  #to remove limits
- Display buildNumber in bottom status bar