### PR TITLE
Fix handling of s2k_fo

### DIFF
--- a/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
+++ b/Xcodes/AppleAPI/Sources/AppleAPI/Client.swift
@@ -313,6 +313,7 @@ public class Client {
         let hashedPasswordDataRaw = sha256(data: passwordData)
         let hashedPasswordData = switch srpProtocol {
         case .s2k: hashedPasswordDataRaw
+        // the legacy s2k_fo protocol requires hex-encoding the digest before performing PBKDF2.
         case .s2k_fo: Data(hashedPasswordDataRaw.hexEncodedString().lowercased().utf8)
         }
 


### PR DESCRIPTION
Apple IDs with "old" passwords (ie those set before a certain date, the cutoff for which I'm not 100% certain) use the `s2k_fo` protocol rather than `s2k`. This legacy protocol involved an extra step in the SRP handshake, where the password was hex-encoded before performing PBKDF2 to derive the shared secret. Luckily it's pretty trivial for us to handle this and fix the erroneous "incorrect username or password" errors that it resulted in.

Closes #644 — this is in fact the root cause behind that issue.