### PR TITLE
Support FIDO2 authentication with devices that don’t have a PIN code

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -357,7 +357,7 @@ class AppState: ObservableObject {
     
     var fido2: FIDO2?
     
-    func createAndSubmitSecurityKeyAssertationWithPinCode(_ pinCode: String, sessionData: AppleSessionData, authOptions: AuthOptionsResponse) {
+    func createAndSubmitSecurityKeyAssertationWithPinCode(_ pinCode: String?, sessionData: AppleSessionData, authOptions: AuthOptionsResponse) {
         self.presentedSheet = .securityKeyTouchToConfirm
         
         guard let fsaChallenge = authOptions.fsaChallenge else {

--- a/Xcodes/Frontend/SignIn/SignInSecurityKeyPinView.swift
+++ b/Xcodes/Frontend/SignIn/SignInSecurityKeyPinView.swift
@@ -32,6 +32,9 @@ struct SignInSecurityKeyPinView: View {
                 Button("Cancel", action: { isPresented = false })
                     .keyboardShortcut(.cancelAction)
                 Spacer()
+
+                Button("PIN not set", action: submitWithoutPinCode)
+
                 ProgressButton(isInProgress: appState.isProcessingAuthRequest,
                                action: submitPinCode) {
                     Text("Continue")
@@ -49,6 +52,10 @@ struct SignInSecurityKeyPinView: View {
     
     func submitPinCode() {
         appState.createAndSubmitSecurityKeyAssertationWithPinCode(pin, sessionData: sessionData, authOptions: authOptions)
+    }
+
+    func submitWithoutPinCode() {
+        appState.createAndSubmitSecurityKeyAssertationWithPinCode(nil, sessionData: sessionData, authOptions: authOptions)
     }
 }
 

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -237,6 +237,16 @@
         }
       }
     },
+    "%@ (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ (%2$@)"
+          }
+        }
+      }
+    },
     "%@ %@ %@" : {
       "localizations" : {
         "ar" : {
@@ -17907,6 +17917,9 @@
           }
         }
       }
+    },
+    "PIN not set" : {
+
     },
     "Platforms" : {
       "localizations" : {


### PR DESCRIPTION
This PR adds support for FIDO2 authentication with devices that don’t have a PIN code set.

This depends on a newer release of the `LibFido2Swift` library. 
At the time of writing `LibFido2Swift` only supports pin-less assertation on the main branch. As such this PR will have to wait until @kinoroy creates a new release on his side.

The button for submitting without a pin was added to be inline with the other buttons on the PIN screen.

![Updated PIN Request flow](https://github.com/user-attachments/assets/67c7edbb-a5bc-4dfe-9d41-57a8aa21f80d)
