### PR TITLE
Update `LibFido2Swift` dependency

### DIFF
--- a/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Xcodes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/kinoroy/LibFido2Swift.git",
         "state": {
           "branch": null,
-          "revision": "b77e5c6451bea69d15615d6578936b11777d9a6c",
-          "version": "0.1.2"
+          "revision": "94d496d6f850dcbb3e8c4a27cd7eeabfad9f14e3",
+          "version": "0.1.4"
         }
       },
       {


### PR DESCRIPTION
The latest version of `LibFido2Swift` contains fix for Google Titan Fido2 key. This fixes the https://github.com/XcodesOrg/XcodesApp/issues/704 issue.