### PR TITLE
feat: improve user experience with a redirect window to sign-in

### DIFF
--- a/Xcodes/Backend/AppState.swift
+++ b/Xcodes/Backend/AppState.swift
@@ -610,7 +610,11 @@ class AppState: ObservableObject {
                     self.installationPublishers[id] = nil
                     if case let .failure(error) = completion {
                         // Prevent setting the app state error if it is an invalid session, we will present the sign in view instead
-                        if error as? AuthenticationError != .invalidSession {
+                        if let error = error as? AuthenticationError, case .notAuthorized = error {
+                            self.error = error
+                            self.presentedAlert = .unauthenticated
+                            
+                        } else if error as? AuthenticationError != .invalidSession {
                             self.error = error
                             self.presentedAlert = .generic(title: localizeString("Alert.Install.Error.Title"), message: error.legibleLocalizedDescription)
                         }

--- a/Xcodes/Frontend/Common/XcodesAlert.swift
+++ b/Xcodes/Frontend/Common/XcodesAlert.swift
@@ -7,6 +7,7 @@ enum XcodesAlert: Identifiable {
     case privilegedHelper
     case generic(title: String, message: String)
     case checkMinSupportedVersion(xcode: AvailableXcode, macOS: String)
+    case unauthenticated
 
     var id: Int {
         switch self {
@@ -15,6 +16,7 @@ enum XcodesAlert: Identifiable {
         case .generic: return 3
         case .checkMinSupportedVersion: return 4
         case .cancelRuntimeInstall: return 5
+        case .unauthenticated: return 6
         }
     }
 }

--- a/Xcodes/Frontend/MainWindow.swift
+++ b/Xcodes/Frontend/MainWindow.swift
@@ -188,6 +188,20 @@ struct MainWindow: View {
                     action: { appState.presentedAlert = nil }
                 )
             )
+        case .unauthenticated:
+            return Alert(
+                title: Text("Alert.Install.Error.Title"),
+                message: Text("Alert.Install.AuthError.Message"),
+                primaryButton: .default(
+                    Text("OK"),
+                    action: {
+                        appState.presentedSheet = .signIn
+                    }
+                ),
+                secondaryButton: .cancel(
+                    Text("Cancel")
+                )
+            )
         case let .checkMinSupportedVersion(xcode, deviceVersion):
             return Alert(
                 title: Text("Alert.MinSupported.Title"),

--- a/Xcodes/Resources/Localizable.xcstrings
+++ b/Xcodes/Resources/Localizable.xcstrings
@@ -1958,6 +1958,16 @@
         }
       }
     },
+    "Alert.Install.AuthError.Message" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You are not authorized. Please Sign in with your Apple ID first."
+          }
+        }
+      }
+    },
     "Alert.Install.Error.Need.Xcode16.1" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION

### Description
In this pull request, I propose adding a redirect window that appears when a new user tries to install an Xcode version but isn’t signed in yet. This alert will redirect the user to the sign-in window, providing a smoother onboarding experience.

### Screens
<img width="1685" height="1052" alt="Screenshot 2025-08-20 at 08 28 54" src="https://github.com/user-attachments/assets/8319fb1f-5465-4f74-a3cb-89d08ea81516" />
<img width="1685" height="1052" alt="Screenshot 2025-08-20 at 08 29 02" src="https://github.com/user-attachments/assets/25f30ca0-f95e-4a6a-a9e1-ab2d25adef96" />
