### PR TITLE
fix: xcode 26 check for Apple Silicon installs

### DIFF
--- a/Scripts/fix_libfido2_framework.sh
+++ b/Scripts/fix_libfido2_framework.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Fix libfido2.framework structure for macOS validation
+# If this script is not run, the build will fail because xcodebuild is expecting the library in a specific structure
+FRAMEWORK_PATH="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks/libfido2.framework"
+
+if [ -d "$FRAMEWORK_PATH" ] && [ -f "$FRAMEWORK_PATH/Info.plist" ] && [ ! -d "$FRAMEWORK_PATH/Versions" ]; then
+    echo "Fixing libfido2.framework bundle structure..."
+
+    # Create proper bundle structure
+    mkdir -p "$FRAMEWORK_PATH/Versions/A/Resources"
+
+    # Move files to proper locations
+    mv "$FRAMEWORK_PATH/Info.plist" "$FRAMEWORK_PATH/Versions/A/Resources/"
+    mv "$FRAMEWORK_PATH/libfido2" "$FRAMEWORK_PATH/Versions/A/"
+    if [ -f "$FRAMEWORK_PATH/LICENSE" ]; then
+        mv "$FRAMEWORK_PATH/LICENSE" "$FRAMEWORK_PATH/Versions/A/"
+    fi
+
+    # Create symbolic links
+    ln -sf A "$FRAMEWORK_PATH/Versions/Current"
+    ln -sf Versions/Current/libfido2 "$FRAMEWORK_PATH/libfido2"
+    ln -sf Versions/Current/Resources "$FRAMEWORK_PATH/Resources"
+
+    echo "libfido2.framework structure fixed"
+fi

--- a/Xcodes.xcodeproj/project.pbxproj
+++ b/Xcodes.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 			buildConfigurationList = CAD2E7BC2449575100113D76 /* Build configuration list for PBXNativeTarget "Xcodes" */;
 			buildPhases = (
 				CAD2E79A2449574E00113D76 /* Sources */,
+				D971F84C2E79102E005F84C9 /* Fix libfido2 structure */,
 				CAD2E79B2449574E00113D76 /* Frameworks */,
 				CA9FF8292594F33200E47BAF /* Generate Acknowledgements */,
 				CAD2E79C2449574E00113D76 /* Resources */,
@@ -875,6 +876,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"${SRCROOT}/Xcodes/AcknowledgementsGenerator\"\nxcrun -sdk macosx swift run AcknowledgementsGenerator \\\n    -p \"${SRCROOT}/Xcodes.xcodeproj\" \\\n    -o \"${SRCROOT}/Xcodes/Resources/Licenses.rtf\"\n";
+		};
+		D971F84C2E79102E005F84C9 /* Fix libfido2 structure */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Fix libfido2 structure";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "${SRCROOT}/Scripts/fix_libfido2_framework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Xcodes/Backend/AppState+Runtimes.swift
+++ b/Xcodes/Backend/AppState+Runtimes.swift
@@ -63,7 +63,8 @@ extension AppState {
             if selectedXcode.version > Version(major: 16, minor: 0, patch: 0) {
                 
                 if runtime.architectures?.isAppleSilicon ?? false {
-                    if selectedXcode.version > Version(major: 26, minor: 0, patch: 0) {
+                    // Need Xcode 26 but with some RC/Beta's its simpler to just to greater > 25
+                    if selectedXcode.version > Version(major: 25, minor: 0, patch: 0) {
                         downloadRuntimeViaXcodeBuild(runtime: runtime)
                     } else {
                         // not supported


### PR DESCRIPTION
To install Apple Silicon runtimes, users will need to have Xcode 26+ selected in order to use the new architecture variant option on xcodebuild. 

This fixes the check as Xcode 26 RC wasn't doing the proper check. Simpler just to say anything over Xcode 25